### PR TITLE
fix: sync paired transfer transaction when one side is edited

### DIFF
--- a/lib/__tests__/applyTransactionUpdate.test.ts
+++ b/lib/__tests__/applyTransactionUpdate.test.ts
@@ -1,0 +1,266 @@
+import Database from 'better-sqlite3';
+import { applyTransactionUpdate, type TxnDb } from '../transactionUpdate';
+
+// Adapts better-sqlite3's synchronous API to the small async surface the
+// real expo-sqlite database exposes for this code path. withTransactionAsync
+// mirrors expo-sqlite's behavior: BEGIN, run the task, COMMIT on success,
+// ROLLBACK on throw.
+function adapt(db: Database.Database): TxnDb {
+  return {
+    runAsync: async (sql, params) => db.prepare(sql).run(...params),
+    getFirstAsync: async <T,>(sql: string, params: any[]) =>
+      (db.prepare(sql).get(...params) as T | undefined) ?? null,
+    withTransactionAsync: async (task) => {
+      db.prepare('BEGIN').run();
+      try {
+        await task();
+        db.prepare('COMMIT').run();
+      } catch (e) {
+        db.prepare('ROLLBACK').run();
+        throw e;
+      }
+    },
+  };
+}
+
+function freshDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE transactions (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      account_id TEXT NOT NULL,
+      txn_date TEXT NOT NULL,
+      payee TEXT NOT NULL,
+      amount REAL NOT NULL,
+      check_number TEXT,
+      memo TEXT,
+      status TEXT NOT NULL,
+      transfer_link_id TEXT,
+      receipt_path TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      _sync_status TEXT NOT NULL
+    );
+    CREATE TABLE transaction_splits (
+      id TEXT PRIMARY KEY,
+      transaction_id TEXT NOT NULL,
+      amount REAL NOT NULL,
+      memo TEXT,
+      _sync_status TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+function seedTransferPair(db: Database.Database, linkId: string) {
+  const insert = db.prepare(`
+    INSERT INTO transactions
+      (id, user_id, account_id, txn_date, payee, amount, memo, status,
+       transfer_link_id, created_at, updated_at, _sync_status)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 'cleared', ?, ?, ?, 'synced')
+  `);
+  insert.run(
+    'from-txn', 'user-1', 'acc-pnc', '2026-05-10',
+    'Transfer to Chase', -66.76, 'Transfer',
+    linkId, '2026-05-10T00:00:00Z', '2026-05-10T00:00:00Z',
+  );
+  insert.run(
+    'to-txn', 'user-1', 'acc-chase', '2026-05-10',
+    'Transfer from PNC', 66.76, 'Transfer',
+    linkId, '2026-05-10T00:00:00Z', '2026-05-10T00:00:00Z',
+  );
+}
+
+describe('applyTransactionUpdate (transfer pair sync)', () => {
+  it('mirrors a corrected amount onto the paired transaction', async () => {
+    const db = freshDb();
+    seedTransferPair(db, 'link-abc');
+
+    const result = await applyTransactionUpdate(
+      adapt(db),
+      {
+        id: 'from-txn',
+        accountId: 'acc-pnc',
+        amount: -63.43,
+      },
+      { now: '2026-05-13T10:00:00Z', newSplitId: () => 'unused' },
+    );
+
+    expect(result.linkedTransactionId).toBe('to-txn');
+    expect(result.linkedAccountId).toBe('acc-chase');
+
+    const rows = db
+      .prepare('SELECT id, amount, _sync_status, updated_at FROM transactions ORDER BY id')
+      .all() as Array<{
+        id: string;
+        amount: number;
+        _sync_status: string;
+        updated_at: string;
+      }>;
+
+    const fromRow = rows.find((r) => r.id === 'from-txn')!;
+    const toRow = rows.find((r) => r.id === 'to-txn')!;
+
+    expect(fromRow.amount).toBe(-63.43);
+    expect(toRow.amount).toBe(63.43);
+    expect(fromRow._sync_status).toBe('pending');
+    expect(toRow._sync_status).toBe('pending');
+    expect(fromRow.updated_at).toBe('2026-05-13T10:00:00Z');
+    expect(toRow.updated_at).toBe('2026-05-13T10:00:00Z');
+  });
+
+  it('propagates date, memo, and status changes to the linked side', async () => {
+    const db = freshDb();
+    seedTransferPair(db, 'link-abc');
+
+    await applyTransactionUpdate(
+      adapt(db),
+      {
+        id: 'from-txn',
+        accountId: 'acc-pnc',
+        txnDate: '2026-05-12',
+        memo: 'Updated memo',
+        status: 'reconciled',
+      },
+      { now: '2026-05-13T10:00:00Z', newSplitId: () => 'unused' },
+    );
+
+    const toRow = db
+      .prepare('SELECT txn_date, memo, status, _sync_status FROM transactions WHERE id = ?')
+      .get('to-txn') as {
+        txn_date: string;
+        memo: string;
+        status: string;
+        _sync_status: string;
+      };
+
+    expect(toRow.txn_date).toBe('2026-05-12');
+    expect(toRow.memo).toBe('Updated memo');
+    expect(toRow.status).toBe('reconciled');
+    expect(toRow._sync_status).toBe('pending');
+  });
+
+  it('does not propagate payee or check_number to the linked side', async () => {
+    const db = freshDb();
+    seedTransferPair(db, 'link-abc');
+
+    await applyTransactionUpdate(
+      adapt(db),
+      {
+        id: 'from-txn',
+        accountId: 'acc-pnc',
+        payee: 'RENAMED ON FROM SIDE',
+        checkNumber: '9999',
+      },
+      { now: '2026-05-13T10:00:00Z', newSplitId: () => 'unused' },
+    );
+
+    const toRow = db
+      .prepare('SELECT payee, check_number FROM transactions WHERE id = ?')
+      .get('to-txn') as { payee: string; check_number: string | null };
+
+    expect(toRow.payee).toBe('Transfer from PNC');
+    expect(toRow.check_number).toBeNull();
+  });
+
+  it('skips the linked deleted row and leaves linkedTransactionId null', async () => {
+    const db = freshDb();
+    seedTransferPair(db, 'link-abc');
+    db.prepare("UPDATE transactions SET _sync_status = 'deleted' WHERE id = 'to-txn'").run();
+
+    const result = await applyTransactionUpdate(
+      adapt(db),
+      {
+        id: 'from-txn',
+        accountId: 'acc-pnc',
+        amount: -10,
+      },
+      { now: '2026-05-13T10:00:00Z', newSplitId: () => 'unused' },
+    );
+
+    expect(result.linkedTransactionId).toBeNull();
+    expect(result.linkedAccountId).toBeNull();
+
+    const toRow = db
+      .prepare('SELECT amount, _sync_status FROM transactions WHERE id = ?')
+      .get('to-txn') as { amount: number; _sync_status: string };
+    expect(toRow.amount).toBe(66.76);
+    expect(toRow._sync_status).toBe('deleted');
+  });
+
+  it('rolls back the primary update when the linked update fails', async () => {
+    const db = freshDb();
+    seedTransferPair(db, 'link-abc');
+
+    const base = adapt(db);
+    // Fail only on the second (linked) UPDATE; the first one (primary) succeeds.
+    let updateCalls = 0;
+    const flaky: TxnDb = {
+      ...base,
+      runAsync: async (sql, params) => {
+        if (sql.startsWith('UPDATE transactions SET ')) {
+          updateCalls++;
+          if (updateCalls === 2) {
+            throw new Error('simulated linked-update failure');
+          }
+        }
+        return base.runAsync(sql, params);
+      },
+    };
+
+    await expect(
+      applyTransactionUpdate(
+        flaky,
+        { id: 'from-txn', accountId: 'acc-pnc', amount: -63.43 },
+        { now: '2026-05-13T10:00:00Z', newSplitId: () => 'unused' },
+      ),
+    ).rejects.toThrow('simulated linked-update failure');
+
+    // Both rows must retain their pre-edit values — neither side committed.
+    const rows = db
+      .prepare('SELECT id, amount, _sync_status, updated_at FROM transactions ORDER BY id')
+      .all() as Array<{
+        id: string;
+        amount: number;
+        _sync_status: string;
+        updated_at: string;
+      }>;
+
+    const fromRow = rows.find((r) => r.id === 'from-txn')!;
+    const toRow = rows.find((r) => r.id === 'to-txn')!;
+
+    expect(fromRow.amount).toBe(-66.76);
+    expect(toRow.amount).toBe(66.76);
+    expect(fromRow._sync_status).toBe('synced');
+    expect(toRow._sync_status).toBe('synced');
+    expect(fromRow.updated_at).toBe('2026-05-10T00:00:00Z');
+    expect(toRow.updated_at).toBe('2026-05-10T00:00:00Z');
+  });
+
+  it('is a no-op for non-transfer transactions', async () => {
+    const db = freshDb();
+    db.prepare(
+      `INSERT INTO transactions
+         (id, user_id, account_id, txn_date, payee, amount, memo, status,
+          transfer_link_id, created_at, updated_at, _sync_status)
+       VALUES ('solo', 'user-1', 'acc-pnc', '2026-05-10', 'Coffee', -4.5, NULL,
+         'cleared', NULL, '2026-05-10T00:00:00Z', '2026-05-10T00:00:00Z', 'synced')`
+    ).run();
+
+    const result = await applyTransactionUpdate(
+      adapt(db),
+      { id: 'solo', accountId: 'acc-pnc', amount: -5 },
+      { now: '2026-05-13T10:00:00Z', newSplitId: () => 'unused' },
+    );
+
+    expect(result.linkedTransactionId).toBeNull();
+    expect(result.linkedAccountId).toBeNull();
+
+    const row = db
+      .prepare('SELECT amount, _sync_status FROM transactions WHERE id = ?')
+      .get('solo') as { amount: number; _sync_status: string };
+    expect(row.amount).toBe(-5);
+    expect(row._sync_status).toBe('pending');
+  });
+});

--- a/lib/__tests__/transferLink.test.ts
+++ b/lib/__tests__/transferLink.test.ts
@@ -1,0 +1,48 @@
+import { pickLinkedTransferUpdate } from '../transferLink';
+
+describe('pickLinkedTransferUpdate', () => {
+  it('mirrors amount sign so the paired account moves the opposite direction', () => {
+    expect(pickLinkedTransferUpdate({ amount: -63.43 })).toEqual({
+      amount: 63.43,
+    });
+    expect(pickLinkedTransferUpdate({ amount: 100 })).toEqual({
+      amount: -100,
+    });
+  });
+
+  it('copies date, memo, and status verbatim', () => {
+    expect(
+      pickLinkedTransferUpdate({
+        txnDate: '2026-05-13',
+        memo: 'Transfer to savings',
+        status: 'reconciled',
+      })
+    ).toEqual({
+      txnDate: '2026-05-13',
+      memo: 'Transfer to savings',
+      status: 'reconciled',
+    });
+  });
+
+  it('preserves null memo', () => {
+    expect(pickLinkedTransferUpdate({ memo: null })).toEqual({ memo: null });
+  });
+
+  it('does not propagate payee or check number to the paired side', () => {
+    const result = pickLinkedTransferUpdate({
+      payee: 'Transfer to Chase',
+      checkNumber: '1001',
+    });
+    expect(result).toEqual({});
+  });
+
+  it('returns only the fields that were provided', () => {
+    expect(pickLinkedTransferUpdate({ status: 'cleared' })).toEqual({
+      status: 'cleared',
+    });
+  });
+
+  it('returns an empty object when no editable fields are present', () => {
+    expect(pickLinkedTransferUpdate({})).toEqual({});
+  });
+});

--- a/lib/hooks/useTransactions.ts
+++ b/lib/hooks/useTransactions.ts
@@ -4,13 +4,18 @@ import { getDb } from '../db';
 import { requestPush } from '../sync';
 import { useAuth } from '../auth';
 import { mapTransaction, mapTransactionSplit } from '../mappers';
+import {
+  applyTransactionUpdate,
+  type UpdateTransactionInput,
+} from '../transactionUpdate';
 import type {
-  Transaction,
   TransactionStatus,
   TransactionWithSplits,
   DbTransaction,
   DbTransactionSplit,
 } from '../types';
+
+export type { UpdateTransactionInput } from '../transactionUpdate';
 
 function txnKeys(accountId: string) {
   return ['transactions', accountId];
@@ -194,18 +199,6 @@ export function useCreateTransaction() {
   });
 }
 
-interface UpdateTransactionInput {
-  id: string;
-  accountId: string;
-  txnDate?: string;
-  payee?: string;
-  amount?: number;
-  checkNumber?: string | null;
-  memo?: string | null;
-  status?: TransactionStatus;
-  splits?: { amount: number; memo: string | null }[];
-}
-
 export function useUpdateTransaction() {
   const { user } = useAuth();
   const qc = useQueryClient();
@@ -217,19 +210,24 @@ export function useUpdateTransaction() {
     if (!old) {
       return old;
     }
+    const primary = old.find((t) => t.id === input.id);
+    const linkId = primary?.transferLinkId ?? null;
     return old.map((t) => {
-      if (t.id !== input.id) {
+      const isPrimary = t.id === input.id;
+      const isLinked =
+        !isPrimary && linkId !== null && t.transferLinkId === linkId;
+      if (!isPrimary && !isLinked) {
         return t;
       }
       const patched = { ...t };
       if (input.status !== undefined) {
         patched.status = input.status;
       }
-      if (input.payee !== undefined) {
+      if (input.payee !== undefined && isPrimary) {
         patched.payee = input.payee;
       }
       if (input.amount !== undefined) {
-        patched.amount = input.amount;
+        patched.amount = isPrimary ? input.amount : -input.amount;
       }
       if (input.txnDate !== undefined) {
         patched.txnDate = input.txnDate;
@@ -237,7 +235,7 @@ export function useUpdateTransaction() {
       if (input.memo !== undefined) {
         patched.memo = input.memo;
       }
-      if (input.checkNumber !== undefined) {
+      if (input.checkNumber !== undefined && isPrimary) {
         patched.checkNumber = input.checkNumber;
       }
       return patched;
@@ -247,65 +245,12 @@ export function useUpdateTransaction() {
   return useMutation({
     mutationFn: async (input: UpdateTransactionInput) => {
       const db = await getDb();
-      const setClauses: string[] = [];
-      const params: any[] = [];
-
-      if (input.txnDate !== undefined) {
-        setClauses.push('txn_date = ?');
-        params.push(input.txnDate);
-      }
-      if (input.payee !== undefined) {
-        setClauses.push('payee = ?');
-        params.push(input.payee);
-      }
-      if (input.amount !== undefined) {
-        setClauses.push('amount = ?');
-        params.push(input.amount);
-      }
-      if (input.checkNumber !== undefined) {
-        setClauses.push('check_number = ?');
-        params.push(input.checkNumber);
-      }
-      if (input.memo !== undefined) {
-        setClauses.push('memo = ?');
-        params.push(input.memo);
-      }
-      if (input.status !== undefined) {
-        setClauses.push('status = ?');
-        params.push(input.status);
-      }
-
-      setClauses.push('updated_at = ?');
-      params.push(new Date().toISOString());
-      setClauses.push("_sync_status = 'pending'");
-      params.push(input.id);
-
-      await db.runAsync(
-        `UPDATE transactions SET ${setClauses.join(', ')} WHERE id = ?`,
-        params
-      );
-
-      if (input.splits !== undefined) {
-        await db.runAsync(
-          'DELETE FROM transaction_splits WHERE transaction_id = ?',
-          [input.id]
-        );
-        for (const s of input.splits) {
-          await db.runAsync(
-            `INSERT INTO transaction_splits
-               (id, transaction_id, amount, memo, _sync_status)
-             VALUES (?, ?, ?, ?, 'pending')`,
-            [Crypto.randomUUID(), input.id, s.amount, s.memo]
-          );
-        }
-      }
-
-      const row = await db.getFirstAsync<DbTransaction>(
-        'SELECT * FROM transactions WHERE id = ?',
-        [input.id]
-      );
+      const result = await applyTransactionUpdate(db, input, {
+        now: new Date().toISOString(),
+        newSplitId: () => Crypto.randomUUID(),
+      });
       requestPush(user!.id);
-      return mapTransaction(row!);
+      return result;
     },
     onMutate: async (input) => {
       await qc.cancelQueries({ queryKey: txnKeys(input.accountId) });
@@ -334,10 +279,18 @@ export function useUpdateTransaction() {
         qc.setQueryData(ALL_TXNS_KEY, context.prevAll);
       }
     },
-    onSettled: (_data, _err, vars) => {
+    onSettled: (data, _err, vars) => {
       qc.invalidateQueries({ queryKey: txnKeys(vars.accountId) });
+      if (data?.linkedAccountId) {
+        qc.invalidateQueries({ queryKey: txnKeys(data.linkedAccountId) });
+      }
       qc.invalidateQueries({ queryKey: ALL_TXNS_KEY });
       qc.invalidateQueries({ queryKey: ['transaction', vars.id] });
+      if (data?.linkedTransactionId) {
+        qc.invalidateQueries({
+          queryKey: ['transaction', data.linkedTransactionId],
+        });
+      }
       qc.invalidateQueries({ queryKey: ['accounts'] });
     },
   });

--- a/lib/transactionUpdate.ts
+++ b/lib/transactionUpdate.ts
@@ -1,0 +1,156 @@
+import { mapTransaction } from './mappers';
+import { pickLinkedTransferUpdate } from './transferLink';
+import type { DbTransaction, Transaction, TransactionStatus } from './types';
+
+export interface UpdateTransactionInput {
+  id: string;
+  accountId: string;
+  txnDate?: string;
+  payee?: string;
+  amount?: number;
+  checkNumber?: string | null;
+  memo?: string | null;
+  status?: TransactionStatus;
+  splits?: { amount: number; memo: string | null }[];
+}
+
+export interface UpdateTransactionResult {
+  txn: Transaction;
+  linkedAccountId: string | null;
+  linkedTransactionId: string | null;
+}
+
+// Slice of the expo-sqlite API this module uses. Defined so tests can run
+// against an in-memory SQLite (better-sqlite3) without the React Query layer.
+export interface TxnDb {
+  runAsync: (sql: string, params: any[]) => Promise<unknown>;
+  getFirstAsync: <T>(sql: string, params: any[]) => Promise<T | null>;
+  withTransactionAsync: (task: () => Promise<void>) => Promise<void>;
+}
+
+export async function applyTransactionUpdate(
+  db: TxnDb,
+  input: UpdateTransactionInput,
+  opts: { now: string; newSplitId: () => string }
+): Promise<UpdateTransactionResult> {
+  const { now, newSplitId } = opts;
+  let linkedAccountId: string | null = null;
+  let linkedTransactionId: string | null = null;
+  let primaryRow: DbTransaction | null = null;
+
+  // All writes go in one SQLite transaction so the from-side, splits, and
+  // to-side either all commit together or roll back together. Without this,
+  // a failure between the primary UPDATE and the linked UPDATE would leave
+  // the transfer pair desynchronized locally — the exact bug this module fixes.
+  await db.withTransactionAsync(async () => {
+    const setClauses: string[] = [];
+    const params: any[] = [];
+
+    if (input.txnDate !== undefined) {
+      setClauses.push('txn_date = ?');
+      params.push(input.txnDate);
+    }
+    if (input.payee !== undefined) {
+      setClauses.push('payee = ?');
+      params.push(input.payee);
+    }
+    if (input.amount !== undefined) {
+      setClauses.push('amount = ?');
+      params.push(input.amount);
+    }
+    if (input.checkNumber !== undefined) {
+      setClauses.push('check_number = ?');
+      params.push(input.checkNumber);
+    }
+    if (input.memo !== undefined) {
+      setClauses.push('memo = ?');
+      params.push(input.memo);
+    }
+    if (input.status !== undefined) {
+      setClauses.push('status = ?');
+      params.push(input.status);
+    }
+
+    setClauses.push('updated_at = ?');
+    params.push(now);
+    setClauses.push("_sync_status = 'pending'");
+    params.push(input.id);
+
+    await db.runAsync(
+      `UPDATE transactions SET ${setClauses.join(', ')} WHERE id = ?`,
+      params
+    );
+
+    if (input.splits !== undefined) {
+      await db.runAsync(
+        'DELETE FROM transaction_splits WHERE transaction_id = ?',
+        [input.id]
+      );
+      for (const s of input.splits) {
+        await db.runAsync(
+          `INSERT INTO transaction_splits
+             (id, transaction_id, amount, memo, _sync_status)
+           VALUES (?, ?, ?, ?, 'pending')`,
+          [newSplitId(), input.id, s.amount, s.memo]
+        );
+      }
+    }
+
+    const linkRow = await db.getFirstAsync<{
+      transfer_link_id: string | null;
+    }>('SELECT transfer_link_id FROM transactions WHERE id = ?', [input.id]);
+    if (linkRow?.transfer_link_id) {
+      const linked = await db.getFirstAsync<{
+        id: string;
+        account_id: string;
+      }>(
+        "SELECT id, account_id FROM transactions WHERE transfer_link_id = ? AND id != ? AND _sync_status != 'deleted'",
+        [linkRow.transfer_link_id, input.id]
+      );
+      if (linked) {
+        linkedAccountId = linked.account_id;
+        linkedTransactionId = linked.id;
+        const linkedFields = pickLinkedTransferUpdate(input);
+        const linkedClauses: string[] = [];
+        const linkedParams: any[] = [];
+        if (linkedFields.txnDate !== undefined) {
+          linkedClauses.push('txn_date = ?');
+          linkedParams.push(linkedFields.txnDate);
+        }
+        if (linkedFields.amount !== undefined) {
+          linkedClauses.push('amount = ?');
+          linkedParams.push(linkedFields.amount);
+        }
+        if (linkedFields.memo !== undefined) {
+          linkedClauses.push('memo = ?');
+          linkedParams.push(linkedFields.memo);
+        }
+        if (linkedFields.status !== undefined) {
+          linkedClauses.push('status = ?');
+          linkedParams.push(linkedFields.status);
+        }
+        if (linkedClauses.length > 0) {
+          linkedClauses.push('updated_at = ?');
+          linkedParams.push(now);
+          linkedClauses.push("_sync_status = 'pending'");
+          linkedParams.push(linked.id);
+          await db.runAsync(
+            `UPDATE transactions SET ${linkedClauses.join(', ')} WHERE id = ?`,
+            linkedParams
+          );
+        }
+      }
+    }
+
+    primaryRow = await db.getFirstAsync<DbTransaction>(
+      'SELECT * FROM transactions WHERE id = ?',
+      [input.id]
+    );
+  });
+
+  return {
+    txn: mapTransaction(primaryRow!),
+    linkedAccountId,
+    linkedTransactionId,
+  };
+}

--- a/lib/transferLink.ts
+++ b/lib/transferLink.ts
@@ -1,0 +1,30 @@
+import type { TransactionStatus } from './types';
+
+export interface TransferEditableFields {
+  txnDate?: string;
+  amount?: number;
+  memo?: string | null;
+  status?: TransactionStatus;
+}
+
+// Fields that mirror to the paired transfer transaction. Payee and check number
+// stay specific to each side (e.g. "Transfer to Chase" vs "Transfer from PNC");
+// amount is sign-flipped so a deduction in one account stays a deposit in the other.
+export function pickLinkedTransferUpdate(
+  input: TransferEditableFields & { payee?: string; checkNumber?: string | null }
+): TransferEditableFields {
+  const out: TransferEditableFields = {};
+  if (input.txnDate !== undefined) {
+    out.txnDate = input.txnDate;
+  }
+  if (input.amount !== undefined) {
+    out.amount = -input.amount;
+  }
+  if (input.memo !== undefined) {
+    out.memo = input.memo;
+  }
+  if (input.status !== undefined) {
+    out.status = input.status;
+  }
+  return out;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,10 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/jest": "29.5.14",
         "@types/react": "~19.1.0",
+        "better-sqlite3": "^12.10.0",
         "jest-expo": "~54.0.17",
         "react-test-renderer": "19.1.0",
         "typescript": "~5.9.2"
@@ -3387,6 +3389,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -4025,6 +4037,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -4032,6 +4059,28 @@
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/bplist-creator": {
@@ -4725,6 +4774,22 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -4949,6 +5014,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -5222,6 +5297,16 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/expect": {
@@ -6001,6 +6086,13 @@
         "asap": "~2.0.3"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -6114,6 +6206,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -6241,6 +6340,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -8835,6 +8941,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -8892,6 +9011,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8927,6 +9053,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8948,6 +9081,32 @@
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -9549,6 +9708,34 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -9644,6 +9831,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -10200,6 +10398,21 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -10674,6 +10887,53 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-plist": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.3.1.tgz",
@@ -10879,6 +11139,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -11051,6 +11321,43 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/yallist": {
@@ -11292,6 +11599,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -11525,6 +11845,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,10 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/jest": "29.5.14",
     "@types/react": "~19.1.0",
+    "better-sqlite3": "^12.10.0",
     "jest-expo": "~54.0.17",
     "react-test-renderer": "19.1.0",
     "typescript": "~5.9.2"


### PR DESCRIPTION
## Summary
- Editing a transfer in one account (e.g. correcting PNC → Chase from \$66.76 to \$63.43) used to leave the other side stale. The mutation now mirrors `amount` (sign-flipped), `txnDate`, `memo`, and `status` onto the linked row; `payee` and `checkNumber` stay side-specific. Cache invalidation extends to the linked account list and the linked transaction detail.
- All writes for the from-side, splits, and linked-side now run inside `db.withTransactionAsync`, so a mid-flight failure rolls back instead of desynchronizing the pair.
- The DB-level logic is extracted into `lib/transactionUpdate.ts` so it can be exercised directly against an in-memory SQLite. `better-sqlite3` is added as a devDependency for that test path.

## Test plan
- [x] `npm test` — 122/122 across 8 suites
- [x] `npx tsc --noEmit` — no new errors (pre-existing `lib/sync.ts` errors are unchanged)
- [x] Unit: `pickLinkedTransferUpdate` covers sign flip, propagated fields, side-specific fields
- [x] DB regression: mirrored amount, propagated date/memo/status, soft-deleted-pair skip, non-transfer no-op
- [x] DB regression: rollback when the linked UPDATE throws — both rows retain pre-edit values
- [x] Manual: edit a transfer's amount in one account on iOS / web, confirm the paired account updates and Supabase receives both rows as pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)