### PR TITLE
fix: stop CSV import and recurring posts from duplicating transactions

### DIFF
--- a/app/import.tsx
+++ b/app/import.tsx
@@ -52,6 +52,7 @@ export default function ImportScreen() {
   const [parsed, setParsed] = useState<ParsedTransaction[]>([]);
   const [importing, setImporting] = useState(false);
   const [importCount, setImportCount] = useState(0);
+  const [skippedCount, setSkippedCount] = useState(0);
 
   const activeAccounts = (accounts ?? []).filter((a) => !a.isArchived);
 
@@ -102,9 +103,36 @@ export default function ImportScreen() {
     try {
       const db = await getDb();
       const now = new Date().toISOString();
+
+      // Dedup guard: skip rows that match an existing non-deleted transaction
+      // in this account on (date, payee, amount). Without this, re-importing
+      // the same CSV (or overlapping statements) silently doubles every row —
+      // each INSERT gets a fresh uuid, so there's no id collision to catch it.
+      // The same `seen` set also dedups within the current batch.
+      const existing = await db.getAllAsync<{
+        txn_date: string;
+        payee: string;
+        amount: number;
+      }>(
+        `SELECT txn_date, payee, amount FROM transactions
+         WHERE account_id = ? AND _sync_status != 'deleted'`,
+        [accountId]
+      );
+      const seen = new Set(
+        existing.map((e) => `${e.txn_date}|${e.payee}|${e.amount}`)
+      );
+
       let count = 0;
+      let skipped = 0;
 
       for (const r of toImport) {
+        const payee = r.payee || '(imported)';
+        const key = `${r.date}|${payee}|${r.amount}`;
+        if (seen.has(key)) {
+          skipped++;
+          continue;
+        }
+        seen.add(key);
         await db.runAsync(
           `INSERT INTO transactions
              (id, user_id, account_id, txn_date, payee, amount, memo,
@@ -112,7 +140,7 @@ export default function ImportScreen() {
            VALUES (?, ?, ?, ?, ?, ?, ?, 'cleared', ?, ?, 'pending')`,
           [
             Crypto.randomUUID(), user!.id, accountId, r.date,
-            r.payee || '(imported)', r.amount, r.memo || null, now, now,
+            payee, r.amount, r.memo || null, now, now,
           ]
         );
         count++;
@@ -120,6 +148,7 @@ export default function ImportScreen() {
 
       requestPush(user!.id);
       setImportCount(count);
+      setSkippedCount(skipped);
       setStep('done');
       qc.invalidateQueries({ queryKey: ['accounts'] });
       qc.invalidateQueries({ queryKey: ['transactions', accountId] });
@@ -140,6 +169,9 @@ export default function ImportScreen() {
           <Text style={[styles.doneTitle, { color: colors.text }]}>Import Complete</Text>
           <Text style={[styles.doneSubtitle, { color: colors.textSecondary }]}>
             {importCount} transaction{importCount !== 1 ? 's' : ''} imported successfully.
+            {skippedCount > 0
+              ? ` ${skippedCount} duplicate${skippedCount !== 1 ? 's' : ''} skipped.`
+              : ''}
           </Text>
           <TouchableOpacity
             style={[styles.primaryBtn, { backgroundColor: colors.tint, alignSelf: 'stretch' }]}

--- a/lib/hooks/useRecurringRules.ts
+++ b/lib/hooks/useRecurringRules.ts
@@ -135,47 +135,69 @@ export function usePostRecurringTransaction() {
       const txnId = Crypto.randomUUID();
       const now = new Date().toISOString();
 
-      await db.runAsync(
-        `INSERT INTO transactions
-           (id, user_id, account_id, txn_date, payee, amount, check_number, memo,
-            status, created_at, updated_at, _sync_status)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, 'pending')`,
-        [
-          txnId, user!.id, rule.accountId, rule.nextDate,
-          rule.template.payee, rule.template.amount,
-          rule.template.checkNumber ?? null, rule.template.memo ?? null,
-          now, now,
-        ]
+      // Idempotency guard: if a non-deleted transaction already exists for
+      // this exact occurrence (account + date + payee + amount), don't post
+      // a second one — just advance the rule. This is what prevents
+      // duplicates after a data-recovery / full re-pull makes an
+      // already-posted rule look "due" again, and it also makes the
+      // insert-then-advance sequence below safe to retry: if a prior post
+      // inserted the txn but crashed before advancing next_date, the retry
+      // finds the existing row and only advances.
+      const existing = await db.getFirstAsync<{ id: string }>(
+        `SELECT id FROM transactions
+         WHERE account_id = ? AND txn_date = ? AND payee = ? AND amount = ?
+           AND _sync_status != 'deleted'
+         LIMIT 1`,
+        [rule.accountId, rule.nextDate, rule.template.payee, rule.template.amount]
       );
-
-      if (rule.template.splits.length > 0) {
-        for (const s of rule.template.splits) {
-          await db.runAsync(
-            `INSERT INTO transaction_splits
-               (id, transaction_id, amount, memo, _sync_status)
-             VALUES (?, ?, ?, ?, 'pending')`,
-            [Crypto.randomUUID(), txnId, s.amount, s.memo]
-          );
-        }
-      }
 
       const newNextDate = advanceDate(rule.nextDate, rule.frequency);
       const isExpired = rule.endDate && newNextDate > rule.endDate;
 
-      if (isExpired) {
-        await db.runAsync(
-          "UPDATE recurring_rules SET _sync_status = 'deleted', updated_at = ? WHERE id = ?",
-          [now, rule.id]
-        );
-      } else {
-        await db.runAsync(
-          "UPDATE recurring_rules SET next_date = ?, updated_at = ?, _sync_status = 'pending' WHERE id = ?",
-          [newNextDate, now, rule.id]
-        );
-      }
+      // Insert (when needed) and advance the rule in one transaction so an
+      // interruption can't leave the txn posted with the rule un-advanced.
+      await db.withTransactionAsync(async () => {
+        if (!existing) {
+          await db.runAsync(
+            `INSERT INTO transactions
+               (id, user_id, account_id, txn_date, payee, amount, check_number, memo,
+                status, created_at, updated_at, _sync_status)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, 'pending')`,
+            [
+              txnId, user!.id, rule.accountId, rule.nextDate,
+              rule.template.payee, rule.template.amount,
+              rule.template.checkNumber ?? null, rule.template.memo ?? null,
+              now, now,
+            ]
+          );
+
+          if (rule.template.splits.length > 0) {
+            for (const s of rule.template.splits) {
+              await db.runAsync(
+                `INSERT INTO transaction_splits
+                   (id, transaction_id, amount, memo, _sync_status)
+                 VALUES (?, ?, ?, ?, 'pending')`,
+                [Crypto.randomUUID(), txnId, s.amount, s.memo]
+              );
+            }
+          }
+        }
+
+        if (isExpired) {
+          await db.runAsync(
+            "UPDATE recurring_rules SET _sync_status = 'deleted', updated_at = ? WHERE id = ?",
+            [now, rule.id]
+          );
+        } else {
+          await db.runAsync(
+            "UPDATE recurring_rules SET next_date = ?, updated_at = ?, _sync_status = 'pending' WHERE id = ?",
+            [newNextDate, now, rule.id]
+          );
+        }
+      });
 
       requestPush(user!.id);
-      return { id: txnId };
+      return { id: existing?.id ?? txnId, skipped: !!existing };
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: RULES_KEY });


### PR DESCRIPTION
## Summary

The two transaction-creation paths each assigned a fresh `uuid` every run with **no deduplication**, so:

- **Re-importing a CSV** (`app/import.tsx`) inserted every row again as a new transaction.
- **Re-posting a recurring occurrence** (`lib/hooks/useRecurringRules.ts`) created another copy — easy to trigger after a data-recovery / full re-pull makes an already-posted rule look "due" again.

Because each copy had a distinct `id`, the id-keyed pull/upsert never caught them, and balances (which sum every non-deleted row) inflated. This was discovered when a fresh full re-pull hydrated the complete Supabase state on a new macOS client.

## Changes

- **CSV import** skips rows matching an existing non-deleted transaction in the account on `(date, payee, amount)`, and dedups within the selected batch. The done screen now reports `N duplicates skipped`.
- **Recurring "Post Now"** guards on `(account, date, payee, amount)`: if a matching non-deleted transaction already exists, it advances the rule **without** posting a second copy. The insert + `next_date` advance now run inside one `withTransactionAsync` (already used elsewhere in the app, web-safe), so an interrupted post can't strand the rule, and a retry is idempotent via the guard.

## Scope

This is the **prevention** half. The existing duplicate rows in Supabase are being cleaned up separately via a reviewed `DELETE` in the Supabase SQL editor (dry-run first); those deletions propagate to all devices through normal sync reconciliation. Independent of PR #5 (sync reconciliation fix).

## Test plan

- [x] `npm test` — 122/122 pass
- [x] Edited files typecheck clean
- [ ] Re-import the same CSV → 0 new rows, "N duplicates skipped" shown
- [ ] Click "Post Now" twice on a due rule → exactly one transaction; `next_date` advances once
- [ ] Normal first-time import and first-time post still work

## Follow-up

Regression tests for both guards (and the PR #5 reconciliation path) once the Supabase/db mock harness exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)