### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Nestworth",
     "slug": "nestworth",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "nestworth",

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -390,7 +390,7 @@ export default function SettingsScreen() {
       </View>
 
       <Text style={[styles.version, { color: colors.placeholder, fontSize: 13 * fontScale }]}>
-        Nestworth v1.0.0
+        Nestworth v1.0.1
       </Text>
     </ScrollView>
   );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checkbook",
   "main": "expo-router/entry",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",


### PR DESCRIPTION
Bumps the app version `1.0.0 → 1.0.1` so the running build is identifiable at a glance.

This was meant to ride along with #7 but landed on the branch ~9 minutes after that PR merged, so it missed the cut. This is just the version bump on its own — no logic changes.

Touches the three independent version spots in lockstep:
- `package.json` — drives the electron-builder `.dmg` + macOS `About` box
- `app.json` — Expo version (iOS / web)
- `app/(tabs)/settings.tsx` — the Settings footer string ("Nestworth v1.0.1") you see on launch

After this merges + the web redeploy / `.dmg` rebuild, all three read 1.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
