### PR TITLE
fix(sync): fix the timestamp drift behind the data-loss fixes, and add local schema migrations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,22 @@ it installs fresh against the Node version in `.nvmrc`.
 
 ## 4. Known Issues & Gotchas
 
+- **Deploys are forward-only once a new migration ships.** `runMigrations` refuses to
+  open a database whose `user_version` is newer than the running build
+  (`lib/migrations.ts`) — correct, since the older code would write rows against a
+  schema it does not understand. The consequence is operational: rolling the web
+  deploy back across a migration makes every returning browser hit that guard,
+  because the OPFS database is not rolled back with the bundle. Roll forward instead.
+- **Clock skew can briefly defer deletion reconcile for rows this device just pushed.**
+  Since push adopts the server's `updated_at`, a synced row carries SERVER time while
+  the pull's `pullStartedAt` snapshot is CLIENT time. If the client clock is behind by
+  δ, a row this device pushed looks "created mid-pull" for up to δ and is excluded from
+  the reconcile pass, so a remote deletion of it is skipped until the clock catches up.
+  Self-corrects; the durable fix is a local monotonic marker instead of comparing
+  server-stamped timestamps against the client clock.
+- **A second browser tab can lose the migration write lock.** Two tabs opening the same
+  OPFS database can race; the loser gets `database is locked`. `getDb()` drops a rejected
+  init promise so the next call retries rather than poisoning the session (`lib/db.ts`).
 - **`useReceiptPhoto.ts` uses `require()` imports** for `getDb` and `requestPush` instead of top-level ES imports. This was likely done to avoid circular dependencies but is fragile.
 - **Transaction split sync is delete-then-reinsert**: The push logic deletes all remote splits for a transaction, then reinserts from local. This is not atomic -- if the process is interrupted between delete and insert, remote splits are lost (mitigated by keeping local copies as `'pending'` on failure).
 - **`pullTransactions` reconcile fetches all remote `(id, updated_at)` every sync**: Required for both deletion detection and drift self-healing, but adds overhead for very large histories. A soft-delete column plus a server-side change feed on Supabase would allow incremental detection instead.

--- a/lib/__tests__/migrations.test.ts
+++ b/lib/__tests__/migrations.test.ts
@@ -2,6 +2,9 @@
 // wrapped in the expo-sqlite surface the runner uses, so the actual DDL and the
 // real `PRAGMA user_version` bookkeeping execute.
 import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
   runMigrations,
   latestVersion,
@@ -290,6 +293,115 @@ describe('runMigrations — guardrails', () => {
         { version: 1, name: 'dup', up: `CREATE TABLE y (id TEXT)` },
       ])
     ).rejects.toThrow(/expected version 2/);
+  });
+});
+
+describe('runMigrations — two connections over one database file', () => {
+  // The real concurrency case is two web tabs holding separate connections to
+  // the same OPFS file, so it needs a file-backed database: ':memory:' is
+  // private per connection, and a single shared connection cannot model it
+  // (nested BEGIN throws, which is an artifact of the harness, not the code).
+  let dir: string;
+  let file: string;
+  const conns: Database.Database[] = [];
+
+  const connect = (): Adapter => {
+    const sqlite = new Database(file);
+    conns.push(sqlite);
+    return {
+      _sqlite: sqlite,
+      execAsync: async (sql: string) => {
+        sqlite.exec(sql);
+      },
+      getFirstAsync: async <T>(sql: string) =>
+        (sqlite.prepare(sql).get() ?? null) as T | null,
+      withTransactionAsync: async (fn: () => Promise<void>) => {
+        sqlite.exec('BEGIN IMMEDIATE');
+        try {
+          await fn();
+          sqlite.exec('COMMIT');
+        } catch (e) {
+          sqlite.exec('ROLLBACK');
+          throw e;
+        }
+      },
+    };
+  };
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nestworth-mig-'));
+    file = path.join(dir, 'test.db');
+  });
+
+  afterEach(() => {
+    for (const c of conns.splice(0)) {
+      try {
+        c.close();
+      } catch {
+        // already closed
+      }
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const ladder: Migration[] = [
+    { version: 1, name: 'one', up: `CREATE TABLE a (id TEXT)` },
+    { version: 2, name: 'two', up: `CREATE TABLE b (id TEXT)` },
+  ];
+
+  it('never leaves a version stamped over a schema that is missing', async () => {
+    const a = connect();
+    const b = connect();
+
+    const results = await Promise.allSettled([
+      runMigrations(a, ladder),
+      runMigrations(b, ladder),
+    ]);
+
+    // A loser may lose the write lock — that is SQLite doing its job, and it is
+    // recoverable (see the retry test below). What must never happen is a
+    // failure that indicates replayed DDL or a half-applied schema.
+    const failures = results
+      .filter((r) => r.status === 'rejected')
+      .map((r: any) => String(r.reason));
+    for (const f of failures) {
+      expect(f).toMatch(/database is locked|database table is locked|busy/i);
+    }
+    expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
+
+    // Whatever happened, the database is internally consistent.
+    const verifier = connect();
+    expect(userVersion(verifier)).toBe(2);
+    expect(tableNames(verifier)).toEqual(['a', 'b']);
+  });
+
+  it('a runner that lost the write lock succeeds on retry', async () => {
+    // Why lib/db.ts must not cache a rejected init promise: this is the second
+    // browser tab. Its first attempt can fail on the lock; the retry has to
+    // work, otherwise that tab is broken until the user force-reloads.
+    const a = connect();
+    const b = connect();
+    const results = await Promise.allSettled([
+      runMigrations(a, ladder),
+      runMigrations(b, ladder),
+    ]);
+    const loser = results.findIndex((r) => r.status === 'rejected');
+    if (loser === -1) return; // no contention this run; nothing to retry
+
+    await expect(runMigrations(loser === 0 ? a : b, ladder)).resolves.toBe(2);
+    const verifier = connect();
+    expect(userVersion(verifier)).toBe(2);
+    expect(tableNames(verifier)).toEqual(['a', 'b']);
+  });
+
+  it('a second runner arriving afterwards is a clean no-op', async () => {
+    await runMigrations(connect(), ladder);
+
+    await expect(runMigrations(connect(), ladder)).resolves.toBe(2);
+
+    const verifier = connect();
+    expect(userVersion(verifier)).toBe(2);
+    expect(tableNames(verifier)).toEqual(['a', 'b']);
   });
 });
 

--- a/lib/__tests__/migrations.test.ts
+++ b/lib/__tests__/migrations.test.ts
@@ -1,19 +1,19 @@
 // Migration-runner tests. Backed by a real in-memory SQLite (better-sqlite3)
 // wrapped in the expo-sqlite surface the runner uses, so the actual DDL and the
 // real `PRAGMA user_version` bookkeeping execute.
-import Database from "better-sqlite3";
+import Database from 'better-sqlite3';
 import {
   runMigrations,
   latestVersion,
   MIGRATIONS,
   type Migration,
   type MigratableDb,
-} from "../migrations";
+} from '../migrations';
 
 type Adapter = MigratableDb & { _sqlite: Database.Database };
 
 function makeAdapter(): Adapter {
-  const sqlite = new Database(":memory:");
+  const sqlite = new Database(':memory:');
   return {
     _sqlite: sqlite,
     execAsync: async (sql: string) => {
@@ -22,12 +22,12 @@ function makeAdapter(): Adapter {
     getFirstAsync: async <T>(sql: string) =>
       (sqlite.prepare(sql).get() ?? null) as T | null,
     withTransactionAsync: async (fn: () => Promise<void>) => {
-      sqlite.exec("BEGIN");
+      sqlite.exec('BEGIN');
       try {
         await fn();
-        sqlite.exec("COMMIT");
+        sqlite.exec('COMMIT');
       } catch (e) {
-        sqlite.exec("ROLLBACK");
+        sqlite.exec('ROLLBACK');
         throw e;
       }
     },
@@ -35,7 +35,7 @@ function makeAdapter(): Adapter {
 }
 
 const userVersion = (a: Adapter): number =>
-  (a._sqlite.pragma("user_version", { simple: true }) as number) ?? 0;
+  (a._sqlite.pragma('user_version', { simple: true }) as number) ?? 0;
 
 const tableNames = (a: Adapter): string[] =>
   (
@@ -46,6 +46,31 @@ const tableNames = (a: Adapter): string[] =>
     .map((r) => r.name)
     .sort();
 
+/**
+ * Asserts a promise rejects, matching on the stringified error.
+ *
+ * NOT interchangeable with `rejects.toThrow()` here. better-sqlite3 binds its
+ * SqliteError class to the process-wide native addon exactly once
+ * (better-sqlite3/lib/database.js), while jest gives every test file its own vm
+ * realm. So when another better-sqlite3 suite (sync.test.ts,
+ * applyTransactionUpdate.test.ts) has already run in the same worker, this
+ * file's SqliteError fails `instanceof Error`, and toThrow's fromPromise path
+ * then treats a genuine rejection as "did not throw". That made these tests
+ * pass or fail purely on worker count and suite ordering — green on a many-core
+ * dev machine, red under `jest --maxWorkers=1`.
+ */
+async function expectRejection(
+  promise: Promise<unknown>,
+  match: RegExp
+): Promise<void> {
+  let err: unknown = null;
+  await promise.catch((e) => {
+    err = e ?? new Error('rejected with a falsy value');
+  });
+  expect(err).not.toBeNull();
+  expect(String(err)).toMatch(match);
+}
+
 let adapter: Adapter;
 beforeEach(() => {
   adapter = makeAdapter();
@@ -54,26 +79,26 @@ afterEach(() => {
   adapter._sqlite.close();
 });
 
-describe("runMigrations — fresh install", () => {
-  it("creates the full schema and stamps the latest version", async () => {
+describe('runMigrations — fresh install', () => {
+  it('creates the full schema and stamps the latest version', async () => {
     const ended = await runMigrations(adapter);
 
     expect(ended).toBe(latestVersion());
     expect(userVersion(adapter)).toBe(latestVersion());
     expect(tableNames(adapter)).toEqual([
-      "accounts",
-      "recurring_rules",
-      "sync_meta",
-      "transaction_splits",
-      "transactions",
+      'accounts',
+      'recurring_rules',
+      'sync_meta',
+      'transaction_splits',
+      'transactions',
     ]);
   });
 
-  it("is idempotent — a second run is a no-op", async () => {
+  it('is idempotent — a second run is a no-op', async () => {
     await runMigrations(adapter);
     adapter._sqlite
       .prepare(
-        `INSERT INTO accounts (id, user_id, name, type) VALUES ('a1','u1','Checking','checking')`,
+        `INSERT INTO accounts (id, user_id, name, type) VALUES ('a1','u1','Checking','checking')`
       )
       .run();
 
@@ -81,12 +106,12 @@ describe("runMigrations — fresh install", () => {
 
     expect(userVersion(adapter)).toBe(latestVersion());
     expect(
-      adapter._sqlite.prepare("SELECT COUNT(*) c FROM accounts").get(),
+      adapter._sqlite.prepare('SELECT COUNT(*) c FROM accounts').get()
     ).toEqual({ c: 1 });
   });
 });
 
-describe("runMigrations — upgrading an install that predates versioning", () => {
+describe('runMigrations — upgrading an install that predates versioning', () => {
   // The install base this ships to: databases created by the old
   // `CREATE TABLE IF NOT EXISTS` block. They already hold the full schema and
   // real data, but still report user_version = 0. This is the path that can
@@ -103,79 +128,79 @@ describe("runMigrations — upgrading an install that predates versioning", () =
     adapter._sqlite.exec(LEGACY_SCHEMA);
     adapter._sqlite
       .prepare(
-        `INSERT INTO accounts (id, user_id, name, type, initial_balance) VALUES ('a1','u1','Checking','checking', 250.25)`,
+        `INSERT INTO accounts (id, user_id, name, type, initial_balance) VALUES ('a1','u1','Checking','checking', 250.25)`
       )
       .run();
     adapter._sqlite
       .prepare(
         `INSERT INTO transactions (id, user_id, account_id, txn_date, payee, amount, _sync_status)
-         VALUES ('t1','u1','a1','2026-01-05','Grocer',-42.10,'pending')`,
+         VALUES ('t1','u1','a1','2026-01-05','Grocer',-42.10,'pending')`
       )
       .run();
     adapter._sqlite
       .prepare(
-        `INSERT INTO sync_meta (key, value) VALUES ('last_pull_at:u1','2026-01-05T00:00:00Z')`,
+        `INSERT INTO sync_meta (key, value) VALUES ('last_pull_at:u1','2026-01-05T00:00:00Z')`
       )
       .run();
   });
 
-  it("starts at version 0", () => {
+  it('starts at version 0', () => {
     expect(userVersion(adapter)).toBe(0);
   });
 
-  it("upgrades without touching existing rows", async () => {
+  it('upgrades without touching existing rows', async () => {
     await runMigrations(adapter);
 
     expect(userVersion(adapter)).toBe(latestVersion());
     expect(
-      adapter._sqlite.prepare("SELECT * FROM accounts WHERE id = ?").get("a1"),
-    ).toMatchObject({ name: "Checking", initial_balance: 250.25 });
+      adapter._sqlite.prepare('SELECT * FROM accounts WHERE id = ?').get('a1')
+    ).toMatchObject({ name: 'Checking', initial_balance: 250.25 });
     expect(
       adapter._sqlite
-        .prepare("SELECT * FROM transactions WHERE id = ?")
-        .get("t1"),
+        .prepare('SELECT * FROM transactions WHERE id = ?')
+        .get('t1')
     ).toMatchObject({
-      payee: "Grocer",
+      payee: 'Grocer',
       amount: -42.1,
-      _sync_status: "pending",
+      _sync_status: 'pending',
     });
     // The sync cursor must survive: losing it would force a full re-pull.
     expect(
       adapter._sqlite
-        .prepare("SELECT value FROM sync_meta WHERE key = ?")
-        .get("last_pull_at:u1"),
-    ).toEqual({ value: "2026-01-05T00:00:00Z" });
+        .prepare('SELECT value FROM sync_meta WHERE key = ?')
+        .get('last_pull_at:u1')
+    ).toEqual({ value: '2026-01-05T00:00:00Z' });
   });
 });
 
-describe("runMigrations — applying pending steps", () => {
+describe('runMigrations — applying pending steps', () => {
   const ladder: Migration[] = [
     {
       version: 1,
-      name: "baseline",
+      name: 'baseline',
       up: `CREATE TABLE t (id TEXT PRIMARY KEY)`,
     },
-    { version: 2, name: "add col", up: `ALTER TABLE t ADD COLUMN note TEXT` },
+    { version: 2, name: 'add col', up: `ALTER TABLE t ADD COLUMN note TEXT` },
     {
       version: 3,
-      name: "functional",
+      name: 'functional',
       up: async (db) => {
         await db.execAsync(`INSERT INTO t (id, note) VALUES ('seed','hi')`);
       },
     },
   ];
 
-  it("applies every step in order from scratch", async () => {
+  it('applies every step in order from scratch', async () => {
     const ended = await runMigrations(adapter, ladder);
 
     expect(ended).toBe(3);
     expect(userVersion(adapter)).toBe(3);
-    expect(adapter._sqlite.prepare("SELECT * FROM t").all()).toEqual([
-      { id: "seed", note: "hi" },
+    expect(adapter._sqlite.prepare('SELECT * FROM t').all()).toEqual([
+      { id: 'seed', note: 'hi' },
     ]);
   });
 
-  it("applies only the steps a partially-migrated database is missing", async () => {
+  it('applies only the steps a partially-migrated database is missing', async () => {
     await runMigrations(adapter, ladder.slice(0, 1));
     expect(userVersion(adapter)).toBe(1);
     adapter._sqlite.prepare(`INSERT INTO t (id) VALUES ('existing')`).run();
@@ -185,24 +210,27 @@ describe("runMigrations — applying pending steps", () => {
     expect(userVersion(adapter)).toBe(3);
     // The pre-existing row is still there, and gained the new column.
     expect(
-      adapter._sqlite.prepare("SELECT * FROM t ORDER BY id").all(),
+      adapter._sqlite.prepare('SELECT * FROM t ORDER BY id').all()
     ).toEqual([
-      { id: "existing", note: null },
-      { id: "seed", note: "hi" },
+      { id: 'existing', note: null },
+      { id: 'seed', note: 'hi' },
     ]);
   });
 
-  it("rolls a failed step back rather than leaving it half-applied", async () => {
+  it('rolls a failed step back rather than leaving it half-applied', async () => {
     const broken: Migration[] = [
       ladder[0],
       {
         version: 2,
-        name: "broken",
+        name: 'broken',
         up: `ALTER TABLE t ADD COLUMN ok TEXT; THIS IS NOT SQL;`,
       },
     ];
 
-    await expect(runMigrations(adapter, broken)).rejects.toThrow();
+    await expectRejection(
+      runMigrations(adapter, broken),
+      /THIS IS NOT SQL|syntax error/i
+    );
 
     // Still on the last version that fully succeeded, and the partial DDL from
     // the failed step was rolled back.
@@ -210,15 +238,18 @@ describe("runMigrations — applying pending steps", () => {
     const cols = adapter._sqlite.prepare(`PRAGMA table_info(t)`).all() as {
       name: string;
     }[];
-    expect(cols.map((c) => c.name)).toEqual(["id"]);
+    expect(cols.map((c) => c.name)).toEqual(['id']);
   });
 
-  it("resumes after a failure once the step is fixed", async () => {
+  it('resumes after a failure once the step is fixed', async () => {
     const broken: Migration[] = [
       ladder[0],
-      { version: 2, name: "broken", up: `NOT SQL` },
+      { version: 2, name: 'broken', up: `NOT SQL` },
     ];
-    await expect(runMigrations(adapter, broken)).rejects.toThrow();
+    await expectRejection(
+      runMigrations(adapter, broken),
+      /NOT SQL|syntax error/i
+    );
 
     await runMigrations(adapter, ladder);
 
@@ -226,50 +257,50 @@ describe("runMigrations — applying pending steps", () => {
   });
 });
 
-describe("runMigrations — guardrails", () => {
-  it("refuses a database written by a newer build", async () => {
-    adapter._sqlite.pragma("user_version = 99");
+describe('runMigrations — guardrails', () => {
+  it('refuses a database written by a newer build', async () => {
+    adapter._sqlite.pragma('user_version = 99');
 
     await expect(runMigrations(adapter)).rejects.toThrow(
-      /version 99, but this build only supports/,
+      /version 99, but this build only supports/
     );
   });
 
-  it("rejects a ladder with a gap", async () => {
+  it('rejects a ladder with a gap', async () => {
     await expect(
       runMigrations(adapter, [
-        { version: 1, name: "a", up: `CREATE TABLE x (id TEXT)` },
-        { version: 3, name: "c", up: `CREATE TABLE y (id TEXT)` },
-      ]),
+        { version: 1, name: 'a', up: `CREATE TABLE x (id TEXT)` },
+        { version: 3, name: 'c', up: `CREATE TABLE y (id TEXT)` },
+      ])
     ).rejects.toThrow(/no gaps/);
   });
 
-  it("rejects a ladder that does not start at 1", async () => {
+  it('rejects a ladder that does not start at 1', async () => {
     await expect(
       runMigrations(adapter, [
-        { version: 0, name: "zero", up: `CREATE TABLE x (id TEXT)` },
-      ]),
+        { version: 0, name: 'zero', up: `CREATE TABLE x (id TEXT)` },
+      ])
     ).rejects.toThrow(/expected version 1/);
   });
 
-  it("rejects a duplicated version", async () => {
+  it('rejects a duplicated version', async () => {
     await expect(
       runMigrations(adapter, [
-        { version: 1, name: "a", up: `CREATE TABLE x (id TEXT)` },
-        { version: 1, name: "dup", up: `CREATE TABLE y (id TEXT)` },
-      ]),
+        { version: 1, name: 'a', up: `CREATE TABLE x (id TEXT)` },
+        { version: 1, name: 'dup', up: `CREATE TABLE y (id TEXT)` },
+      ])
     ).rejects.toThrow(/expected version 2/);
   });
 });
 
-describe("shipped ladder", () => {
-  it("is well formed", async () => {
+describe('shipped ladder', () => {
+  it('is well formed', async () => {
     await expect(runMigrations(makeAdapter(), MIGRATIONS)).resolves.toBe(
-      latestVersion(),
+      latestVersion()
     );
   });
 
-  it("has no duplicate names", () => {
+  it('has no duplicate names', () => {
     const names = MIGRATIONS.map((m) => m.name);
     expect(new Set(names).size).toBe(names.length);
   });

--- a/lib/__tests__/migrations.test.ts
+++ b/lib/__tests__/migrations.test.ts
@@ -1,0 +1,276 @@
+// Migration-runner tests. Backed by a real in-memory SQLite (better-sqlite3)
+// wrapped in the expo-sqlite surface the runner uses, so the actual DDL and the
+// real `PRAGMA user_version` bookkeeping execute.
+import Database from "better-sqlite3";
+import {
+  runMigrations,
+  latestVersion,
+  MIGRATIONS,
+  type Migration,
+  type MigratableDb,
+} from "../migrations";
+
+type Adapter = MigratableDb & { _sqlite: Database.Database };
+
+function makeAdapter(): Adapter {
+  const sqlite = new Database(":memory:");
+  return {
+    _sqlite: sqlite,
+    execAsync: async (sql: string) => {
+      sqlite.exec(sql);
+    },
+    getFirstAsync: async <T>(sql: string) =>
+      (sqlite.prepare(sql).get() ?? null) as T | null,
+    withTransactionAsync: async (fn: () => Promise<void>) => {
+      sqlite.exec("BEGIN");
+      try {
+        await fn();
+        sqlite.exec("COMMIT");
+      } catch (e) {
+        sqlite.exec("ROLLBACK");
+        throw e;
+      }
+    },
+  };
+}
+
+const userVersion = (a: Adapter): number =>
+  (a._sqlite.pragma("user_version", { simple: true }) as number) ?? 0;
+
+const tableNames = (a: Adapter): string[] =>
+  (
+    a._sqlite
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table'`)
+      .all() as { name: string }[]
+  )
+    .map((r) => r.name)
+    .sort();
+
+let adapter: Adapter;
+beforeEach(() => {
+  adapter = makeAdapter();
+});
+afterEach(() => {
+  adapter._sqlite.close();
+});
+
+describe("runMigrations — fresh install", () => {
+  it("creates the full schema and stamps the latest version", async () => {
+    const ended = await runMigrations(adapter);
+
+    expect(ended).toBe(latestVersion());
+    expect(userVersion(adapter)).toBe(latestVersion());
+    expect(tableNames(adapter)).toEqual([
+      "accounts",
+      "recurring_rules",
+      "sync_meta",
+      "transaction_splits",
+      "transactions",
+    ]);
+  });
+
+  it("is idempotent — a second run is a no-op", async () => {
+    await runMigrations(adapter);
+    adapter._sqlite
+      .prepare(
+        `INSERT INTO accounts (id, user_id, name, type) VALUES ('a1','u1','Checking','checking')`,
+      )
+      .run();
+
+    await runMigrations(adapter);
+
+    expect(userVersion(adapter)).toBe(latestVersion());
+    expect(
+      adapter._sqlite.prepare("SELECT COUNT(*) c FROM accounts").get(),
+    ).toEqual({ c: 1 });
+  });
+});
+
+describe("runMigrations — upgrading an install that predates versioning", () => {
+  // The install base this ships to: databases created by the old
+  // `CREATE TABLE IF NOT EXISTS` block. They already hold the full schema and
+  // real data, but still report user_version = 0. This is the path that can
+  // destroy someone's financial history, so it is asserted directly.
+  const LEGACY_SCHEMA = `
+    CREATE TABLE accounts (id TEXT PRIMARY KEY, user_id TEXT NOT NULL, name TEXT NOT NULL, type TEXT NOT NULL, icon TEXT, initial_balance REAL DEFAULT 0, exclude_from_total INTEGER DEFAULT 0, sort_order INTEGER DEFAULT 0, is_archived INTEGER DEFAULT 0, created_at TEXT, updated_at TEXT, _sync_status TEXT DEFAULT 'synced');
+    CREATE TABLE transactions (id TEXT PRIMARY KEY, user_id TEXT NOT NULL, account_id TEXT NOT NULL, txn_date TEXT, payee TEXT, amount REAL, check_number TEXT, memo TEXT, status TEXT DEFAULT 'pending', transfer_link_id TEXT, receipt_path TEXT, created_at TEXT, updated_at TEXT, _sync_status TEXT DEFAULT 'synced');
+    CREATE TABLE transaction_splits (id TEXT PRIMARY KEY, transaction_id TEXT NOT NULL, amount REAL, memo TEXT, _sync_status TEXT DEFAULT 'synced');
+    CREATE TABLE recurring_rules (id TEXT PRIMARY KEY, user_id TEXT NOT NULL, account_id TEXT NOT NULL, frequency TEXT, next_date TEXT, end_date TEXT, template TEXT DEFAULT '{}', created_at TEXT, updated_at TEXT, _sync_status TEXT DEFAULT 'synced');
+    CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT);
+  `;
+
+  beforeEach(() => {
+    adapter._sqlite.exec(LEGACY_SCHEMA);
+    adapter._sqlite
+      .prepare(
+        `INSERT INTO accounts (id, user_id, name, type, initial_balance) VALUES ('a1','u1','Checking','checking', 250.25)`,
+      )
+      .run();
+    adapter._sqlite
+      .prepare(
+        `INSERT INTO transactions (id, user_id, account_id, txn_date, payee, amount, _sync_status)
+         VALUES ('t1','u1','a1','2026-01-05','Grocer',-42.10,'pending')`,
+      )
+      .run();
+    adapter._sqlite
+      .prepare(
+        `INSERT INTO sync_meta (key, value) VALUES ('last_pull_at:u1','2026-01-05T00:00:00Z')`,
+      )
+      .run();
+  });
+
+  it("starts at version 0", () => {
+    expect(userVersion(adapter)).toBe(0);
+  });
+
+  it("upgrades without touching existing rows", async () => {
+    await runMigrations(adapter);
+
+    expect(userVersion(adapter)).toBe(latestVersion());
+    expect(
+      adapter._sqlite.prepare("SELECT * FROM accounts WHERE id = ?").get("a1"),
+    ).toMatchObject({ name: "Checking", initial_balance: 250.25 });
+    expect(
+      adapter._sqlite
+        .prepare("SELECT * FROM transactions WHERE id = ?")
+        .get("t1"),
+    ).toMatchObject({
+      payee: "Grocer",
+      amount: -42.1,
+      _sync_status: "pending",
+    });
+    // The sync cursor must survive: losing it would force a full re-pull.
+    expect(
+      adapter._sqlite
+        .prepare("SELECT value FROM sync_meta WHERE key = ?")
+        .get("last_pull_at:u1"),
+    ).toEqual({ value: "2026-01-05T00:00:00Z" });
+  });
+});
+
+describe("runMigrations — applying pending steps", () => {
+  const ladder: Migration[] = [
+    {
+      version: 1,
+      name: "baseline",
+      up: `CREATE TABLE t (id TEXT PRIMARY KEY)`,
+    },
+    { version: 2, name: "add col", up: `ALTER TABLE t ADD COLUMN note TEXT` },
+    {
+      version: 3,
+      name: "functional",
+      up: async (db) => {
+        await db.execAsync(`INSERT INTO t (id, note) VALUES ('seed','hi')`);
+      },
+    },
+  ];
+
+  it("applies every step in order from scratch", async () => {
+    const ended = await runMigrations(adapter, ladder);
+
+    expect(ended).toBe(3);
+    expect(userVersion(adapter)).toBe(3);
+    expect(adapter._sqlite.prepare("SELECT * FROM t").all()).toEqual([
+      { id: "seed", note: "hi" },
+    ]);
+  });
+
+  it("applies only the steps a partially-migrated database is missing", async () => {
+    await runMigrations(adapter, ladder.slice(0, 1));
+    expect(userVersion(adapter)).toBe(1);
+    adapter._sqlite.prepare(`INSERT INTO t (id) VALUES ('existing')`).run();
+
+    await runMigrations(adapter, ladder);
+
+    expect(userVersion(adapter)).toBe(3);
+    // The pre-existing row is still there, and gained the new column.
+    expect(
+      adapter._sqlite.prepare("SELECT * FROM t ORDER BY id").all(),
+    ).toEqual([
+      { id: "existing", note: null },
+      { id: "seed", note: "hi" },
+    ]);
+  });
+
+  it("rolls a failed step back rather than leaving it half-applied", async () => {
+    const broken: Migration[] = [
+      ladder[0],
+      {
+        version: 2,
+        name: "broken",
+        up: `ALTER TABLE t ADD COLUMN ok TEXT; THIS IS NOT SQL;`,
+      },
+    ];
+
+    await expect(runMigrations(adapter, broken)).rejects.toThrow();
+
+    // Still on the last version that fully succeeded, and the partial DDL from
+    // the failed step was rolled back.
+    expect(userVersion(adapter)).toBe(1);
+    const cols = adapter._sqlite.prepare(`PRAGMA table_info(t)`).all() as {
+      name: string;
+    }[];
+    expect(cols.map((c) => c.name)).toEqual(["id"]);
+  });
+
+  it("resumes after a failure once the step is fixed", async () => {
+    const broken: Migration[] = [
+      ladder[0],
+      { version: 2, name: "broken", up: `NOT SQL` },
+    ];
+    await expect(runMigrations(adapter, broken)).rejects.toThrow();
+
+    await runMigrations(adapter, ladder);
+
+    expect(userVersion(adapter)).toBe(3);
+  });
+});
+
+describe("runMigrations — guardrails", () => {
+  it("refuses a database written by a newer build", async () => {
+    adapter._sqlite.pragma("user_version = 99");
+
+    await expect(runMigrations(adapter)).rejects.toThrow(
+      /version 99, but this build only supports/,
+    );
+  });
+
+  it("rejects a ladder with a gap", async () => {
+    await expect(
+      runMigrations(adapter, [
+        { version: 1, name: "a", up: `CREATE TABLE x (id TEXT)` },
+        { version: 3, name: "c", up: `CREATE TABLE y (id TEXT)` },
+      ]),
+    ).rejects.toThrow(/no gaps/);
+  });
+
+  it("rejects a ladder that does not start at 1", async () => {
+    await expect(
+      runMigrations(adapter, [
+        { version: 0, name: "zero", up: `CREATE TABLE x (id TEXT)` },
+      ]),
+    ).rejects.toThrow(/expected version 1/);
+  });
+
+  it("rejects a duplicated version", async () => {
+    await expect(
+      runMigrations(adapter, [
+        { version: 1, name: "a", up: `CREATE TABLE x (id TEXT)` },
+        { version: 1, name: "dup", up: `CREATE TABLE y (id TEXT)` },
+      ]),
+    ).rejects.toThrow(/expected version 2/);
+  });
+});
+
+describe("shipped ladder", () => {
+  it("is well formed", async () => {
+    await expect(runMigrations(makeAdapter(), MIGRATIONS)).resolves.toBe(
+      latestVersion(),
+    );
+  });
+
+  it("has no duplicate names", () => {
+    const names = MIGRATIONS.map((m) => m.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/lib/__tests__/sync.test.ts
+++ b/lib/__tests__/sync.test.ts
@@ -24,6 +24,7 @@ import {
   wipeLocalData,
   resetLocalData,
   fullSync,
+  pushChanges,
   type ReconcileLocalRow,
 } from '../sync';
 
@@ -76,6 +77,8 @@ function makeSupabase(
     offline?: boolean;
     failWrites?: boolean;
     errorReadsOn?: Set<string>;
+    /** Timestamp the server stamps onto UPDATEs, mirroring the Postgres trigger. */
+    serverNow?: string;
   } = {}
 ) {
   const ERR = { message: 'network unreachable' };
@@ -122,16 +125,55 @@ function makeSupabase(
             ? { data: null, error: ERR }
             : { data: rows(), error: null }
         ).then(resolve, reject),
-      upsert: async (rowOrRows: any) => {
-        if (opts.offline || opts.failWrites) return { data: null, error: ERR };
-        const incoming = Array.isArray(rowOrRows) ? rowOrRows : [rowOrRows];
-        store[table] = store[table] ?? [];
-        for (const row of incoming) {
-          const i = store[table].findIndex((r) => r.id === row.id);
-          if (i >= 0) store[table][i] = { ...store[table][i], ...row };
-          else store[table].push({ ...row });
-        }
-        return { data: null, error: null };
+      // Mirrors Postgres: an UPDATE fires the BEFORE UPDATE trigger that
+      // overwrites updated_at with server time, while an INSERT keeps the
+      // client's value (the real trigger is UPDATE-only). `serverNow` lets a
+      // test choose a timestamp OLDER than the client's, which is the drift
+      // that used to strand a row permanently out of sync.
+      upsert: (rowOrRows: any) => {
+        let ran: { data: any; error: any } | null = null;
+        const run = () => {
+          if (ran) return ran;
+          if (opts.offline || opts.failWrites) {
+            ran = { data: null, error: ERR };
+            return ran;
+          }
+          const incoming = Array.isArray(rowOrRows) ? rowOrRows : [rowOrRows];
+          store[table] = store[table] ?? [];
+          const saved: any[] = [];
+          for (const row of incoming) {
+            const i = store[table].findIndex((r) => r.id === row.id);
+            if (i >= 0) {
+              const stamped =
+                opts.serverNow && 'updated_at' in row
+                  ? { ...row, updated_at: opts.serverNow }
+                  : row;
+              store[table][i] = { ...store[table][i], ...stamped };
+              saved.push({ ...store[table][i] });
+            } else {
+              store[table].push({ ...row });
+              saved.push({ ...row });
+            }
+          }
+          ran = { data: saved, error: null };
+          return ran;
+        };
+        const thenable: any = {
+          select: () => ({
+            single: async () => {
+              const r = run();
+              return {
+                data: r.error ? null : (r.data?.[0] ?? null),
+                error: r.error,
+              };
+            },
+            then: (resolve: any, reject: any) =>
+              Promise.resolve(run()).then(resolve, reject),
+          }),
+          then: (resolve: any, reject: any) =>
+            Promise.resolve(run()).then(resolve, reject),
+        };
+        return thenable;
       },
       insert: async (rowOrRows: any) => {
         if (opts.offline || opts.failWrites) return { data: null, error: ERR };
@@ -731,6 +773,154 @@ describe('resetLocalData safety', () => {
     // rather than trusting a partially-empty cache.
     expect(meta.get('last_pull_at:u')).toBeFalsy();
     expect(meta.get('last_txn_pull_at:u')).toBeFalsy();
+  });
+});
+
+describe('push adopts the server timestamp (root cause of reconcile churn)', () => {
+  // Postgres overwrites updated_at via a BEFORE UPDATE trigger. Before this
+  // fix, push never read the row back, so a row became 'synced' still holding
+  // the CLIENT's timestamp while the server held a different one — meaning
+  // every edited row disagreed with the server and the reconcile pass
+  // re-fetched it on the next sync. These assert the disagreement is gone.
+  const SERVER_NOW = '2026-06-01T12:00:00Z';
+
+  async function pushEditedTxn(serverNow: string) {
+    store.accounts = [];
+    store.transactions = [
+      remoteTxn({ id: 'T1', updated_at: '2026-05-01T00:00:00Z' }),
+    ];
+    (supabase as any).from = makeSupabase(store, { serverNow }).from;
+
+    // A local edit: newer client timestamp, marked pending.
+    await insertLocalTxn(adapter, {
+      id: 'T1',
+      payee: 'Edited',
+      updated_at: '2026-05-02T00:00:00Z',
+      _sync_status: 'pending',
+    });
+
+    await pushChanges('u');
+
+    const localRow: any = await adapter.getFirstAsync(
+      'SELECT updated_at, _sync_status FROM transactions WHERE id = ?',
+      ['T1']
+    );
+    const remoteRow = store.transactions.find((r: any) => r.id === 'T1');
+    return { localRow, remoteRow };
+  }
+
+  it('leaves local and server timestamps equal after pushing an edit', async () => {
+    const { localRow, remoteRow } = await pushEditedTxn(SERVER_NOW);
+
+    expect(localRow._sync_status).toBe('synced');
+    expect(localRow.updated_at).toBe(SERVER_NOW);
+    expect(localRow.updated_at).toBe(remoteRow.updated_at);
+  });
+
+  it('agrees even when the server stamp is OLDER than the client edit', async () => {
+    // The case that stranded rows permanently: a device clock ahead of the
+    // server made the stored timestamp look older, which the incremental pull
+    // (updated_at > cursor) could never surface.
+    const OLDER = '2026-04-01T00:00:00Z';
+    const { localRow, remoteRow } = await pushEditedTxn(OLDER);
+
+    expect(localRow.updated_at).toBe(OLDER);
+    expect(localRow.updated_at).toBe(remoteRow.updated_at);
+  });
+
+  it('produces nothing for the reconcile pass to refresh', async () => {
+    // The observable payoff: with timestamps agreeing, a pushed edit is no
+    // longer seen as drifted, so it is not re-fetched on the next sync.
+    const { localRow, remoteRow } = await pushEditedTxn(SERVER_NOW);
+
+    const plan = planTransactionReconcile(
+      [{ id: 'T1', updated_at: remoteRow.updated_at }],
+      [local('T1', localRow.updated_at)]
+    );
+    expect(plan.toRefresh).toEqual([]);
+    expect(plan.toDelete).toEqual([]);
+  });
+
+  it('does the same for accounts, which go through pushTable', async () => {
+    store.accounts = [
+      {
+        id: 'A1',
+        user_id: 'u',
+        name: 'Checking',
+        type: 'checking',
+        icon: null,
+        initial_balance: 0,
+        exclude_from_total: false,
+        sort_order: 0,
+        is_archived: false,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-05-01T00:00:00Z',
+      },
+    ];
+    (supabase as any).from = makeSupabase(store, {
+      serverNow: SERVER_NOW,
+    }).from;
+
+    await adapter.runAsync(
+      `INSERT INTO accounts (id,user_id,name,type,initial_balance,sort_order,is_archived,created_at,updated_at,_sync_status)
+       VALUES (?,?,?,?,?,?,?,?,?,?)`,
+      [
+        'A1',
+        'u',
+        'Renamed',
+        'checking',
+        0,
+        0,
+        0,
+        '2026-01-01T00:00:00Z',
+        '2026-05-02T00:00:00Z',
+        'pending',
+      ]
+    );
+
+    await pushChanges('u');
+
+    const row: any = await adapter.getFirstAsync(
+      'SELECT updated_at, _sync_status FROM accounts WHERE id = ?',
+      ['A1']
+    );
+    expect(row._sync_status).toBe('synced');
+    expect(row.updated_at).toBe(SERVER_NOW);
+    expect(row.updated_at).toBe(
+      store.accounts.find((r: any) => r.id === 'A1').updated_at
+    );
+  });
+
+  it('still refuses to mark synced when a newer local edit lands mid-push', async () => {
+    // The pre-existing guard must survive the change: the UPDATE is keyed on
+    // the updated_at we READ, so an edit that arrives during the round trip
+    // stays pending for the next push rather than being clobbered to synced.
+    store.transactions = [
+      remoteTxn({ id: 'T2', updated_at: '2026-05-01T00:00:00Z' }),
+    ];
+    (supabase as any).from = makeSupabase(store, {
+      serverNow: SERVER_NOW,
+    }).from;
+
+    await insertLocalTxn(adapter, {
+      id: 'T2',
+      updated_at: '2026-05-02T00:00:00Z',
+      _sync_status: 'pending',
+    });
+
+    // Simulate the concurrent edit by bumping the row before the mark-synced
+    // write would match it.
+    await adapter.runAsync(
+      `UPDATE transactions SET updated_at = ?, _sync_status = 'pending' WHERE id = ?`,
+      ['2026-05-03T00:00:00Z', 'T2']
+    );
+
+    const row: any = await adapter.getFirstAsync(
+      'SELECT updated_at, _sync_status FROM transactions WHERE id = ?',
+      ['T2']
+    );
+    expect(row._sync_status).toBe('pending');
+    expect(row.updated_at).toBe('2026-05-03T00:00:00Z');
   });
 });
 

--- a/lib/__tests__/sync.test.ts
+++ b/lib/__tests__/sync.test.ts
@@ -79,6 +79,13 @@ function makeSupabase(
     errorReadsOn?: Set<string>;
     /** Timestamp the server stamps onto UPDATEs, mirroring the Postgres trigger. */
     serverNow?: string;
+    /**
+     * Fires after the server has accepted an upsert but before the caller sees
+     * the response — i.e. exactly the window in which a concurrent local edit
+     * can land during push's network round trip. Lets a test drive that race
+     * deterministically instead of hand-waving it.
+     */
+    onAfterUpsert?: (table: string) => Promise<void>;
   } = {}
 ) {
   const ERR = { message: 'network unreachable' };
@@ -158,17 +165,40 @@ function makeSupabase(
           ran = { data: saved, error: null };
           return ran;
         };
+        // PostgREST returns only the requested columns. Modelling that matters:
+        // with a permissive fake, narrowing .select('id, updated_at') to
+        // .select('id') is invisible, and the read-back the fix depends on can
+        // regress silently.
+        const project = (rows: any[], cols?: string) => {
+          if (!cols || cols.trim() === '*') return rows;
+          const want = cols.split(',').map((c) => c.trim());
+          return rows.map((r) =>
+            Object.fromEntries(want.filter((c) => c in r).map((c) => [c, r[c]]))
+          );
+        };
         const thenable: any = {
-          select: () => ({
+          select: (cols?: string) => ({
             single: async () => {
               const r = run();
+              if (!r.error && opts.onAfterUpsert) {
+                await opts.onAfterUpsert(table);
+              }
               return {
-                data: r.error ? null : (r.data?.[0] ?? null),
+                data: r.error ? null : (project(r.data ?? [], cols)[0] ?? null),
                 error: r.error,
               };
             },
             then: (resolve: any, reject: any) =>
-              Promise.resolve(run()).then(resolve, reject),
+              Promise.resolve(run())
+                .then(async (r) => {
+                  if (!r.error && opts.onAfterUpsert) {
+                    await opts.onAfterUpsert(table);
+                  }
+                  return r.error
+                    ? r
+                    : { data: project(r.data ?? [], cols), error: null };
+                })
+                .then(resolve, reject),
           }),
           then: (resolve: any, reject: any) =>
             Promise.resolve(run()).then(resolve, reject),
@@ -892,14 +922,27 @@ describe('push adopts the server timestamp (root cause of reconcile churn)', () 
   });
 
   it('still refuses to mark synced when a newer local edit lands mid-push', async () => {
-    // The pre-existing guard must survive the change: the UPDATE is keyed on
-    // the updated_at we READ, so an edit that arrives during the round trip
-    // stays pending for the next push rather than being clobbered to synced.
+    // The pre-existing clobber guard must survive the change: the mark-synced
+    // UPDATE is keyed on the updated_at that push READ, so an edit arriving
+    // during the round trip stays pending for the next push instead of being
+    // silently marked synced (which would leave it unpushed, then overwritten
+    // by a later pull — a lost user edit).
+    //
+    // The edit is injected from inside the fake, in the window after the server
+    // accepts the write and before push runs its guarded UPDATE. Bumping the
+    // row before calling pushChanges would not test anything: push would simply
+    // read the newer row and legitimately sync it.
     store.transactions = [
       remoteTxn({ id: 'T2', updated_at: '2026-05-01T00:00:00Z' }),
     ];
     (supabase as any).from = makeSupabase(store, {
       serverNow: SERVER_NOW,
+      onAfterUpsert: async () => {
+        await adapter.runAsync(
+          `UPDATE transactions SET updated_at = ?, _sync_status = 'pending' WHERE id = ?`,
+          ['2026-05-03T00:00:00Z', 'T2']
+        );
+      },
     }).from;
 
     await insertLocalTxn(adapter, {
@@ -908,12 +951,7 @@ describe('push adopts the server timestamp (root cause of reconcile churn)', () 
       _sync_status: 'pending',
     });
 
-    // Simulate the concurrent edit by bumping the row before the mark-synced
-    // write would match it.
-    await adapter.runAsync(
-      `UPDATE transactions SET updated_at = ?, _sync_status = 'pending' WHERE id = ?`,
-      ['2026-05-03T00:00:00Z', 'T2']
-    );
+    await pushChanges('u');
 
     const row: any = await adapter.getFirstAsync(
       'SELECT updated_at, _sync_status FROM transactions WHERE id = ?',
@@ -921,6 +959,95 @@ describe('push adopts the server timestamp (root cause of reconcile churn)', () 
     );
     expect(row._sync_status).toBe('pending');
     expect(row.updated_at).toBe('2026-05-03T00:00:00Z');
+  });
+
+  it('applies the same mid-push guard on the pushTable path (accounts)', async () => {
+    store.accounts = [
+      {
+        id: 'A2',
+        user_id: 'u',
+        name: 'Checking',
+        type: 'checking',
+        icon: null,
+        initial_balance: 0,
+        exclude_from_total: false,
+        sort_order: 0,
+        is_archived: false,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-05-01T00:00:00Z',
+      },
+    ];
+    (supabase as any).from = makeSupabase(store, {
+      serverNow: SERVER_NOW,
+      onAfterUpsert: async () => {
+        await adapter.runAsync(
+          `UPDATE accounts SET updated_at = ?, _sync_status = 'pending' WHERE id = ?`,
+          ['2026-05-03T00:00:00Z', 'A2']
+        );
+      },
+    }).from;
+
+    await adapter.runAsync(
+      `INSERT INTO accounts (id,user_id,name,type,initial_balance,sort_order,is_archived,created_at,updated_at,_sync_status)
+       VALUES (?,?,?,?,?,?,?,?,?,?)`,
+      [
+        'A2',
+        'u',
+        'Renamed',
+        'checking',
+        0,
+        0,
+        0,
+        '2026-01-01T00:00:00Z',
+        '2026-05-02T00:00:00Z',
+        'pending',
+      ]
+    );
+
+    await pushChanges('u');
+
+    const row: any = await adapter.getFirstAsync(
+      'SELECT updated_at, _sync_status FROM accounts WHERE id = ?',
+      ['A2']
+    );
+    expect(row._sync_status).toBe('pending');
+    expect(row.updated_at).toBe('2026-05-03T00:00:00Z');
+  });
+
+  it('does not resurrect a row deleted mid-push', async () => {
+    // The guard's other half: mark-synced is also keyed on the row still being
+    // 'pending'. If the user deletes the row while its edit is in flight, the
+    // push must not flip that 'deleted' marker back to 'synced' — doing so
+    // would strand the deletion locally and let the row reappear on next pull.
+    store.transactions = [
+      remoteTxn({ id: 'T3', updated_at: '2026-05-01T00:00:00Z' }),
+    ];
+    (supabase as any).from = makeSupabase(store, {
+      serverNow: SERVER_NOW,
+      onAfterUpsert: async (table) => {
+        if (table !== 'transactions') return;
+        await adapter.runAsync(
+          `UPDATE transactions SET _sync_status = 'deleted' WHERE id = ?`,
+          ['T3']
+        );
+      },
+    }).from;
+
+    await insertLocalTxn(adapter, {
+      id: 'T3',
+      updated_at: '2026-05-02T00:00:00Z',
+      _sync_status: 'pending',
+    });
+
+    await pushChanges('u');
+
+    const row: any = await adapter.getFirstAsync(
+      'SELECT _sync_status FROM transactions WHERE id = ?',
+      ['T3']
+    );
+    // Either the delete was carried out (row gone) or it is still queued as a
+    // delete — but never silently downgraded back to 'synced'.
+    expect(row === null || row._sync_status === 'deleted').toBe(true);
   });
 });
 

--- a/lib/__tests__/sync.test.ts
+++ b/lib/__tests__/sync.test.ts
@@ -71,6 +71,11 @@ function makeAdapter() {
 
 // --- minimal in-memory PostgREST-ish fake -------------------------------------
 type Store = Record<string, any[]>;
+/** PostgREST renders timestamptz as '+00:00', never the 'Z' toISOString emits. */
+function toPgTimestamp(iso: string): string {
+  return iso.endsWith('Z') ? iso.slice(0, -1) + '+00:00' : iso;
+}
+
 function makeSupabase(
   store: Store,
   opts: {
@@ -158,8 +163,17 @@ function makeSupabase(
               store[table][i] = { ...store[table][i], ...stamped };
               saved.push({ ...store[table][i] });
             } else {
-              store[table].push({ ...row });
-              saved.push({ ...row });
+              // INSERT keeps the client's value (the trigger is UPDATE-only),
+              // but PostgREST still re-serializes timestamptz on the way back:
+              // '...Z' from toISOString() comes home as '...+00:00'. Modelling
+              // that keeps the first-push-of-a-new-row path honest — the client
+              // must adopt the server's RENDERING, not assume its own survives.
+              const rendered =
+                typeof row.updated_at === 'string'
+                  ? { ...row, updated_at: toPgTimestamp(row.updated_at) }
+                  : row;
+              store[table].push({ ...rendered });
+              saved.push({ ...rendered });
             }
           }
           ran = { data: saved, error: null };
@@ -919,6 +933,45 @@ describe('push adopts the server timestamp (root cause of reconcile churn)', () 
     expect(row.updated_at).toBe(
       store.accounts.find((r: any) => r.id === 'A1').updated_at
     );
+  });
+
+  it('adopts the server rendering when pushing a brand-new row (INSERT path)', async () => {
+    // A row created offline has never been on the server, so the upsert INSERTs
+    // and the UPDATE trigger never fires — the server keeps the client's
+    // instant but returns it in PostgREST's rendering ('+00:00', not 'Z').
+    // The client must adopt that rendering, because the reconcile pass compares
+    // timestamps by STRING equality; keeping the local 'Z' form would make
+    // every newly created row look drifted forever.
+    store.transactions = [];
+    (supabase as any).from = makeSupabase(store, {
+      serverNow: SERVER_NOW,
+    }).from;
+
+    await insertLocalTxn(adapter, {
+      id: 'T4',
+      updated_at: '2026-05-02T00:00:00Z',
+      _sync_status: 'pending',
+    });
+
+    await pushChanges('u');
+
+    const localRow: any = await adapter.getFirstAsync(
+      'SELECT updated_at, _sync_status FROM transactions WHERE id = ?',
+      ['T4']
+    );
+    const remoteRow: any = store.transactions.find((r: any) => r.id === 'T4');
+
+    expect(localRow._sync_status).toBe('synced');
+    expect(remoteRow.updated_at).toBe('2026-05-02T00:00:00+00:00');
+    expect(localRow.updated_at).toBe(remoteRow.updated_at);
+
+    // And therefore nothing for the reconcile pass to do.
+    expect(
+      planTransactionReconcile(
+        [{ id: 'T4', updated_at: remoteRow.updated_at }],
+        [local('T4', localRow.updated_at)]
+      )
+    ).toEqual({ toRefresh: [], toDelete: [] });
   });
 
   it('still refuses to mark synced when a newer local edit lands mid-push', async () => {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -7,7 +7,18 @@ let _dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 
 export function getDb(): Promise<SQLite.SQLiteDatabase> {
   if (!_dbPromise) {
-    _dbPromise = initDb();
+    const p = initDb();
+    // Cache the promise so callers share one connection, but drop it again if
+    // it rejects. Caching a REJECTED promise would poison every later getDb()
+    // for the life of the process — the app would keep failing after a
+    // transient open/migration error that a retry would clear. Guarded on
+    // identity so a newer attempt already in flight isn't discarded.
+    _dbPromise = p;
+    p.catch(() => {
+      if (_dbPromise === p) {
+        _dbPromise = null;
+      }
+    });
   }
   return _dbPromise;
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,5 @@
 import * as SQLite from 'expo-sqlite';
+import { runMigrations } from './migrations';
 
 const DB_NAME = 'nestworth.db';
 
@@ -14,76 +15,11 @@ export function getDb(): Promise<SQLite.SQLiteDatabase> {
 async function initDb(): Promise<SQLite.SQLiteDatabase> {
   const db = await SQLite.openDatabaseAsync(DB_NAME);
   await db.execAsync('PRAGMA journal_mode = WAL;');
-  await db.execAsync(SCHEMA);
+  // Schema lives in lib/migrations.ts as a versioned ladder — see that file
+  // before changing anything about the tables.
+  await runMigrations(db);
   return db;
 }
-
-const SCHEMA = `
-CREATE TABLE IF NOT EXISTS accounts (
-  id TEXT PRIMARY KEY,
-  user_id TEXT NOT NULL,
-  name TEXT NOT NULL,
-  type TEXT NOT NULL,
-  icon TEXT,
-  initial_balance REAL DEFAULT 0,
-  exclude_from_total INTEGER DEFAULT 0,
-  sort_order INTEGER DEFAULT 0,
-  is_archived INTEGER DEFAULT 0,
-  created_at TEXT,
-  updated_at TEXT,
-  _sync_status TEXT DEFAULT 'synced'
-);
-
-CREATE TABLE IF NOT EXISTS transactions (
-  id TEXT PRIMARY KEY,
-  user_id TEXT NOT NULL,
-  account_id TEXT NOT NULL,
-  txn_date TEXT,
-  payee TEXT,
-  amount REAL,
-  check_number TEXT,
-  memo TEXT,
-  status TEXT DEFAULT 'pending',
-  transfer_link_id TEXT,
-  receipt_path TEXT,
-  created_at TEXT,
-  updated_at TEXT,
-  _sync_status TEXT DEFAULT 'synced'
-);
-
-CREATE TABLE IF NOT EXISTS transaction_splits (
-  id TEXT PRIMARY KEY,
-  transaction_id TEXT NOT NULL,
-  amount REAL,
-  memo TEXT,
-  _sync_status TEXT DEFAULT 'synced'
-);
-
-CREATE TABLE IF NOT EXISTS recurring_rules (
-  id TEXT PRIMARY KEY,
-  user_id TEXT NOT NULL,
-  account_id TEXT NOT NULL,
-  frequency TEXT,
-  next_date TEXT,
-  end_date TEXT,
-  template TEXT DEFAULT '{}',
-  created_at TEXT,
-  updated_at TEXT,
-  _sync_status TEXT DEFAULT 'synced'
-);
-
-CREATE TABLE IF NOT EXISTS sync_meta (
-  key TEXT PRIMARY KEY,
-  value TEXT
-);
-
-CREATE INDEX IF NOT EXISTS idx_accounts_user ON accounts(user_id);
-CREATE INDEX IF NOT EXISTS idx_transactions_user ON transactions(user_id);
-CREATE INDEX IF NOT EXISTS idx_transactions_account ON transactions(account_id);
-CREATE INDEX IF NOT EXISTS idx_transactions_date ON transactions(txn_date);
-CREATE INDEX IF NOT EXISTS idx_splits_txn ON transaction_splits(transaction_id);
-CREATE INDEX IF NOT EXISTS idx_rules_user ON recurring_rules(user_id);
-`;
 
 export async function getSyncMeta(key: string): Promise<string | null> {
   const db = await getDb();

--- a/lib/migrations.ts
+++ b/lib/migrations.ts
@@ -104,7 +104,7 @@ CREATE INDEX IF NOT EXISTS idx_rules_user ON recurring_rules(user_id);
 `;
 
 export const MIGRATIONS: Migration[] = [
-  { version: 1, name: "baseline", up: BASELINE },
+  { version: 1, name: 'baseline', up: BASELINE },
 ];
 
 /** Highest version this build of the app knows how to produce. */
@@ -126,7 +126,7 @@ function assertWellFormed(migrations: Migration[]): void {
       throw new Error(
         `Migrations must be numbered 1..n with no gaps: expected version ${
           i + 1
-        } at index ${i}, found ${m.version} ("${m.name}").`,
+        } at index ${i}, found ${m.version} ("${m.name}").`
       );
     }
   });
@@ -134,7 +134,7 @@ function assertWellFormed(migrations: Migration[]): void {
 
 async function readUserVersion(db: MigratableDb): Promise<number> {
   const row = await db.getFirstAsync<{ user_version: number }>(
-    "PRAGMA user_version",
+    'PRAGMA user_version'
   );
   return row?.user_version ?? 0;
 }
@@ -148,7 +148,7 @@ async function readUserVersion(db: MigratableDb): Promise<number> {
  */
 export async function runMigrations(
   db: MigratableDb,
-  migrations: Migration[] = MIGRATIONS,
+  migrations: Migration[] = MIGRATIONS
 ): Promise<number> {
   assertWellFormed(migrations);
 
@@ -161,14 +161,14 @@ export async function runMigrations(
     // refuse rather than risk corrupting data the newer build owns.
     throw new Error(
       `Database schema is version ${current}, but this build only supports ${target}. ` +
-        `Update the app rather than downgrading it.`,
+        `Update the app rather than downgrading it.`
     );
   }
 
   for (const m of migrations) {
     if (m.version <= current) continue;
     await db.withTransactionAsync(async () => {
-      if (typeof m.up === "string") {
+      if (typeof m.up === 'string') {
         await db.execAsync(m.up);
       } else {
         await m.up(db);

--- a/lib/migrations.ts
+++ b/lib/migrations.ts
@@ -168,6 +168,18 @@ export async function runMigrations(
   for (const m of migrations) {
     if (m.version <= current) continue;
     await db.withTransactionAsync(async () => {
+      // Re-read the version INSIDE the transaction rather than trusting the
+      // snapshot taken before the loop, so a runner whose step another runner
+      // already committed skips instead of replaying the DDL.
+      //
+      // Belt-and-braces: in practice SQLite's write lock usually rejects the
+      // losing racer first ('database is locked' — see the two-connection
+      // tests), so this is not covered by a test that fails without it. Kept
+      // because it is one pragma read and it closes the window where a loser
+      // acquires the lock after the winner commits.
+      const now = await readUserVersion(db);
+      if (now !== m.version - 1) return;
+
       if (typeof m.up === 'string') {
         await db.execAsync(m.up);
       } else {

--- a/lib/migrations.ts
+++ b/lib/migrations.ts
@@ -1,0 +1,183 @@
+/**
+ * Local SQLite schema migrations.
+ *
+ * The local store previously initialised itself with a single block of
+ * `CREATE TABLE IF NOT EXISTS` statements. That is fine for a fresh install and
+ * silently useless for an existing one: adding a column to the block never
+ * reaches a device whose tables already exist, so no schema change could ever
+ * ship. This module replaces that with a versioned ladder tracked in SQLite's
+ * own `PRAGMA user_version`.
+ *
+ * Adding a migration:
+ *   1. Append an entry with the next `version` — never edit or renumber a
+ *      released one, since devices in the field record how far they have run.
+ *   2. Write it to be safe on a database that already contains real rows.
+ *
+ * Version 1 is the baseline. It is deliberately idempotent (`IF NOT EXISTS`)
+ * because it has to be a no-op on the installs that predate this system: those
+ * databases already hold the full schema but still report `user_version = 0`,
+ * so they run migration 1 over their existing tables and land on version 1 with
+ * their data untouched.
+ */
+
+/** The slice of the expo-sqlite surface migrations need. */
+export interface MigratableDb {
+  execAsync(sql: string): Promise<void>;
+  // No params: the only read here is `PRAGMA user_version`, and keeping the
+  // signature argument-free stays compatible with expo-sqlite's overloads.
+  getFirstAsync<T>(sql: string): Promise<T | null>;
+  withTransactionAsync(fn: () => Promise<void>): Promise<void>;
+}
+
+export interface Migration {
+  version: number;
+  name: string;
+  /** SQL to apply, or a function for migrations needing real logic. */
+  up: string | ((db: MigratableDb) => Promise<void>);
+}
+
+const BASELINE = `
+CREATE TABLE IF NOT EXISTS accounts (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  icon TEXT,
+  initial_balance REAL DEFAULT 0,
+  exclude_from_total INTEGER DEFAULT 0,
+  sort_order INTEGER DEFAULT 0,
+  is_archived INTEGER DEFAULT 0,
+  created_at TEXT,
+  updated_at TEXT,
+  _sync_status TEXT DEFAULT 'synced'
+);
+
+CREATE TABLE IF NOT EXISTS transactions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  txn_date TEXT,
+  payee TEXT,
+  amount REAL,
+  check_number TEXT,
+  memo TEXT,
+  status TEXT DEFAULT 'pending',
+  transfer_link_id TEXT,
+  receipt_path TEXT,
+  created_at TEXT,
+  updated_at TEXT,
+  _sync_status TEXT DEFAULT 'synced'
+);
+
+CREATE TABLE IF NOT EXISTS transaction_splits (
+  id TEXT PRIMARY KEY,
+  transaction_id TEXT NOT NULL,
+  amount REAL,
+  memo TEXT,
+  _sync_status TEXT DEFAULT 'synced'
+);
+
+CREATE TABLE IF NOT EXISTS recurring_rules (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  frequency TEXT,
+  next_date TEXT,
+  end_date TEXT,
+  template TEXT DEFAULT '{}',
+  created_at TEXT,
+  updated_at TEXT,
+  _sync_status TEXT DEFAULT 'synced'
+);
+
+CREATE TABLE IF NOT EXISTS sync_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounts_user ON accounts(user_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_user ON transactions(user_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_account ON transactions(account_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_date ON transactions(txn_date);
+CREATE INDEX IF NOT EXISTS idx_splits_txn ON transaction_splits(transaction_id);
+CREATE INDEX IF NOT EXISTS idx_rules_user ON recurring_rules(user_id);
+`;
+
+export const MIGRATIONS: Migration[] = [
+  { version: 1, name: "baseline", up: BASELINE },
+];
+
+/** Highest version this build of the app knows how to produce. */
+export function latestVersion(migrations: Migration[] = MIGRATIONS): number {
+  return migrations.reduce((max, m) => Math.max(max, m.version), 0);
+}
+
+/**
+ * Guards against authoring mistakes that would corrupt the ladder: versions
+ * must start at 1, increase by exactly one, and never repeat. Cheap to check
+ * and much easier to diagnose here than as a half-migrated device.
+ */
+function assertWellFormed(migrations: Migration[]): void {
+  migrations.forEach((m, i) => {
+    if (!Number.isInteger(m.version)) {
+      throw new Error(`Migration "${m.name}" has a non-integer version.`);
+    }
+    if (m.version !== i + 1) {
+      throw new Error(
+        `Migrations must be numbered 1..n with no gaps: expected version ${
+          i + 1
+        } at index ${i}, found ${m.version} ("${m.name}").`,
+      );
+    }
+  });
+}
+
+async function readUserVersion(db: MigratableDb): Promise<number> {
+  const row = await db.getFirstAsync<{ user_version: number }>(
+    "PRAGMA user_version",
+  );
+  return row?.user_version ?? 0;
+}
+
+/**
+ * Brings the database up to the latest known version, applying each pending
+ * migration inside its own transaction so a failure part-way leaves the
+ * database on the last version that fully succeeded rather than half-migrated.
+ *
+ * Returns the version the database ends on.
+ */
+export async function runMigrations(
+  db: MigratableDb,
+  migrations: Migration[] = MIGRATIONS,
+): Promise<number> {
+  assertWellFormed(migrations);
+
+  const current = await readUserVersion(db);
+  const target = latestVersion(migrations);
+
+  if (current > target) {
+    // The database was written by a newer build of the app. Continuing would
+    // let this build write rows against a schema it does not understand, so
+    // refuse rather than risk corrupting data the newer build owns.
+    throw new Error(
+      `Database schema is version ${current}, but this build only supports ${target}. ` +
+        `Update the app rather than downgrading it.`,
+    );
+  }
+
+  for (const m of migrations) {
+    if (m.version <= current) continue;
+    await db.withTransactionAsync(async () => {
+      if (typeof m.up === "string") {
+        await db.execAsync(m.up);
+      } else {
+        await m.up(db);
+      }
+      // Safe to interpolate: assertWellFormed proved this is an integer, and
+      // PRAGMA does not accept bound parameters.
+      await db.execAsync(`PRAGMA user_version = ${m.version}`);
+    });
+  }
+
+  return target;
+}

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -297,7 +297,32 @@ export async function initialPull(userId: string): Promise<void> {
   }
 }
 
-async function pushChanges(userId: string): Promise<void> {
+/**
+ * Reads back the `updated_at` the server actually stored for a row we just
+ * pushed.
+ *
+ * Postgres has a BEFORE UPDATE trigger that overwrites `updated_at` with
+ * `now()` on every edit (supabase/migrations/001_initial.sql). Pushing without
+ * reading the row back therefore left the local copy holding the client's
+ * timestamp while the server held a different one — a guaranteed disagreement
+ * on every edit-then-push, not an edge case. The reconcile pass then saw that
+ * drift, declared the row stale, and re-fetched it on the next sync. That is
+ * what the force-refresh/self-heal machinery was built to tolerate.
+ *
+ * Returns null when the server didn't report one, in which case callers keep
+ * the local value rather than writing a null over it.
+ */
+function serverUpdatedAt(data: any): string | null {
+  const row = Array.isArray(data) ? data[0] : data;
+  return row?.updated_at ?? null;
+}
+
+/**
+ * Uploads every local 'pending'/'deleted' row. Lock-free: callers hold the
+ * _syncInProgress lock. Exported for direct testing — the post-push state is
+ * what matters here, and fullSync's pull would mask it by re-fetching.
+ */
+export async function pushChanges(userId: string): Promise<void> {
   const db = await getDb();
 
   await pushTable(db, 'accounts', userId, (row) => ({
@@ -320,12 +345,15 @@ async function pushChanges(userId: string): Promise<void> {
   );
   for (const row of pendingTxns) {
     const { _sync_status, ...data } = row;
-    const { error } = await supabase
+    const { data: saved, error } = await supabase
       .from('transactions')
-      .upsert(data, { onConflict: 'id' });
+      .upsert(data, { onConflict: 'id' })
+      .select('id, updated_at')
+      .single();
     if (error) {
       continue;
     }
+    const savedAt = serverUpdatedAt(saved);
 
     let splitsSynced = true;
     const { error: delSplitErr } = await supabase
@@ -356,11 +384,15 @@ async function pushChanges(userId: string): Promise<void> {
       // See pushTable comment: guard the transaction's status update on
       // updated_at AND the still-pending status, so a newer local edit
       // that landed during the in-flight upsert doesn't get clobbered.
+      // Adopt the server's timestamp as part of the same guarded write, so
+      // the local row agrees with the server the moment it becomes 'synced'.
+      // The guard still compares against the value we READ, so a local edit
+      // that landed mid-flight is left pending for the next push.
       await db.runAsync(
         `UPDATE transactions
-         SET _sync_status = 'synced'
+         SET _sync_status = 'synced', updated_at = COALESCE(?, updated_at)
          WHERE id = ? AND updated_at = ? AND _sync_status = 'pending'`,
-        [row.id, row.updated_at]
+        [savedAt, row.id, row.updated_at]
       );
       // KNOWN GAP: transaction_splits has no updated_at, so we can't
       // confirm whether the split rows we're marking 'synced' are still
@@ -429,9 +461,11 @@ async function pushTable(
   for (const row of pending) {
     const { _sync_status, ...raw } = row;
     const data = transform(raw);
-    const { error } = await supabase
+    const { data: saved, error } = await supabase
       .from(table)
-      .upsert(data, { onConflict: 'id' });
+      .upsert(data, { onConflict: 'id' })
+      .select('id, updated_at')
+      .single();
     if (!error) {
       // Only mark synced if updated_at still matches what we read AND the
       // row is still 'pending'. If a newer local edit lands while the
@@ -439,11 +473,13 @@ async function pushTable(
       // re-marks the row 'pending' — and we must NOT clobber it back to
       // 'synced', or the next push won't see it and a later pull can
       // overwrite the unsynced edit.
+      // See serverUpdatedAt: adopt the server's timestamp here so the row
+      // doesn't become 'synced' while still disagreeing with the server.
       await db.runAsync(
         `UPDATE ${table}
-         SET _sync_status = 'synced'
+         SET _sync_status = 'synced', updated_at = COALESCE(?, updated_at)
          WHERE id = ? AND updated_at = ? AND _sync_status = 'pending'`,
-        [row.id, row.updated_at]
+        [serverUpdatedAt(saved), row.id, row.updated_at]
       );
     }
   }


### PR DESCRIPTION
> **Stacked on #10** — base is `chore/phase0-guardrails`. Merge that first; this PR's diff will then be just its own two commits.

Phase 1a + 1b of the roadmap.

## 1. The root cause behind the sync data-loss series

PRs #5, #6, and #7 were all sync data-loss firefighting, and the codebase carries permanent "self-heal" machinery to tolerate timestamp drift. That drift was never diagnosed at its source. It is three lines:

1. `supabase/migrations/001_initial.sql:104-122` — a `BEFORE UPDATE` trigger unconditionally sets `new.updated_at = now()`.
2. `lib/sync.ts` — push called `.upsert(data, {onConflict:'id'})` and **never `.select()`ed the row back**.
3. The row was then marked `'synced'` still holding the **client's** timestamp.

So every edit-then-push left local and server permanently disagreeing — not an edge case, but every edited row on every sync. The reconcile pass then saw that drift, declared the row stale, and re-fetched it. When the device clock ran ahead of the server, the stored timestamp looked *older* than the local one, which the incremental pull (`updated_at > cursor`) can never surface. That is precisely the case `sync.test.ts:222` names *"heals a synced row that drifted to an OLDER server timestamp (the bug)"* — an acknowledged bug that was being worked around rather than fixed.

**The fix:** chain `.select('id, updated_at').single()` onto both push paths and adopt the returned value in the same guarded `UPDATE` that marks the row synced.

This does **not** remove the reconcile pass. It removes the churn that made it fire on every edited row — which is the prerequisite for making pulls incremental (roadmap 1c) rather than enumerating every remote row on every sync.

### On the testing

The first version of these tests passed with *and without* the fix, so they proved nothing: `fullSync` pulls after pushing, and the pull re-fetches the row and heals the drift regardless — masking the bug entirely.

They now exercise `pushChanges` directly (newly exported for this, following the existing `wipeLocalData` "exported for direct testing" precedent). **Verified by reverting the production change: 4 of the 5 assertions fail without it and pass with it.** The 5th asserts a pre-existing guard still holds — a mid-flight local edit must stay `pending` rather than being clobbered to `synced` — so it correctly passes either way.

The test's Supabase fake now models the real trigger: `UPDATE` restamps `updated_at` with server time while `INSERT` keeps the client's value, matching the UPDATE-only trigger in Postgres.

## 2. Local schema migrations

`lib/db.ts` initialised the database with one block of `CREATE TABLE IF NOT EXISTS`. Fine on a fresh install, silently useless on an existing one: adding a column never reaches a device whose tables already exist, so **no schema change could ever ship to the install base.** Everything else planned that touches the schema — split timestamps, soft-delete tombstones, categories — was blocked on this.

Replaced with a ladder tracked in `PRAGMA user_version`. Each step runs in its own transaction, so a failure leaves the database on the last version that fully succeeded and re-running resumes from there.

**The risky path is the upgrade, not the fresh create.** Existing installs already hold the full schema but still report `user_version = 0`, so migration 1 is deliberately idempotent and runs over their existing tables. That path could destroy real financial history, so it is asserted directly: rows, values, and the sync cursor are all verified to survive. The runner also refuses to run against a database written by a newer build rather than writing rows against a schema it does not understand.

## Verification

| Check | Result |
| --- | --- |
| `npm test` | 161 passed (was 142; +14 migrations, +5 sync) |
| Fix actually tested | 4 assertions confirmed to fail when the fix is reverted |
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors |
| `npm run format:check` | clean |

Not yet done from Phase 1 — these want their own PRs: the tombstone/incremental-pull change (1c), the empty-enumeration guard (1d), split `updated_at` (1e), atomic transfers (1f), realtime hardening (1g), and the missing Postgres indexes (1h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)