### PR TITLE
docs: document notarization via a keychain profile, not env vars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,14 @@ project directory rather than merely gitignored -- a gitignore does not protect 
 archives, editor indexing, or `git add -f`. `backups/` remains in `.gitignore` as a
 safety net in case a script recreates it.
 
+**macOS notarization credentials** live in a `notarytool` keychain profile, not in
+environment variables. Create it once with `xcrun notarytool store-credentials nestworth
+--apple-id <id> --team-id P9KK9LA3ZV`, then build with
+`APPLE_KEYCHAIN_PROFILE=nestworth npm run electron:build`. Verify a finished build with
+`spctl --assess --type execute -vv dist-electron/mac-arm64/Nestworth.app`, which must say
+`source=Notarized Developer ID` -- electron-builder silently skips notarization when it
+finds no credentials, so a green build is not proof.
+
 **Gotcha -- stale native module after a Node upgrade:** `better-sqlite3` (used by the
 sync unit tests) is compiled against a specific `NODE_MODULE_VERSION`. After changing
 Node versions locally the suite fails with `Cannot read properties of undefined

--- a/README.md
+++ b/README.md
@@ -216,11 +216,27 @@ npm run electron:dev       # exports the web bundle, compiles main, opens a wind
 Signed/notarized build:
 
 ```bash
-export APPLE_ID="you@example.com"
-export APPLE_APP_SPECIFIC_PASSWORD="abcd-efgh-ijkl-mnop"
-export APPLE_TEAM_ID="<your-10-char-team-id>"
-npm run electron:build     # produces dist-electron/Nestworth-<version>-arm64.dmg
+# One-time: store the app-specific password in the keychain.
+xcrun notarytool store-credentials nestworth \
+  --apple-id "you@example.com" --team-id "<your-10-char-team-id>"
+
+# Every build after that:
+APPLE_KEYCHAIN_PROFILE=nestworth npm run electron:build
 ```
+
+This produces `dist-electron/Nestworth-<version>-arm64.dmg`.
+
+`store-credentials` prompts for the app-specific password once and keeps it in
+the login keychain, so it never has to live in an environment variable, a shell
+history, or a dotfile. electron-builder also accepts `APPLE_ID` +
+`APPLE_APP_SPECIFIC_PASSWORD` + `APPLE_TEAM_ID` as environment variables, but
+exporting a password makes it readable by every child process of that shell --
+prefer the keychain profile.
+
+If no credentials are found, electron-builder logs `skipped macOS notarization`
+and still emits a signed `.dmg`. That build runs locally but Gatekeeper will
+block it on any other Mac, so check the verification below rather than assuming
+a successful build was notarized.
 
 (The team ID is the same value already present at `appleTeamId` in `app.json`. It's a public identifier and is also embedded in every signed binary -- not a secret.)
 


### PR DESCRIPTION
## Why

The README's build instructions exported the app-specific password:

```bash
export APPLE_APP_SPECIFIC_PASSWORD="abcd-efgh-ijkl-mnop"
```

Anything exported is readable by every child process of that shell, and passwords written into a build command tend to end up in shell history and dotfiles.

`xcrun notarytool store-credentials` takes the password once, stores it in the login keychain, and electron-builder reads it through `APPLE_KEYCHAIN_PROFILE` — so the secret is never exported at all. Verified end-to-end on the v1.0.2 build: signed → notarized → stapled, `spctl` reports `accepted, source=Notarized Developer ID`.

The env-var route still works and is still mentioned; it's just no longer the documented default.

## Also documented

electron-builder logs `skipped macOS notarization` and **still emits a signed `.dmg`** when it finds no credentials. That build runs on the machine that made it and is blocked by Gatekeeper everywhere else — so a green build is not evidence of notarization. Both README and CONTRIBUTING now say to verify with `spctl --assess --type execute -vv`.

Docs only — no code or build config changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)