### PR TITLE
chore: rename the npm package from checkbook to nestworth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "checkbook",
+  "name": "nestworth",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "checkbook",
+      "name": "nestworth",
       "version": "1.0.1",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "checkbook",
+  "name": "nestworth",
   "main": "expo-router/entry",
   "version": "1.0.1",
   "scripts": {


### PR DESCRIPTION
## Why

The project was renamed to Nestworth after the repo was created, but `package.json` still said `"name": "checkbook"`. Everything else already used the new name — `productName` in `electron-builder.yml`, the app name in `app.json`, the GitHub repo, and now the local working directory. This was the last stale reference.

## Risk

Minimal. The package is `private: true` and never published, and nothing reads the `name` field — no jest `displayName`, no electron-builder reference, no script that greps for it.

Updates `package.json` and the two matching entries in `package-lock.json`.

## Verification

167 tests pass · typecheck clean · Prettier clean · `npm run electron:tsc` compiles · `npm ls` resolves the tree intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)