### PR TITLE
fix(ci): pin Netlify's Node version after the .nvmrc removal

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,12 @@
 [build]
   command = "npm test && npx expo export -p web"
   publish = "dist"
+
+# Netlify picks its Node version from .nvmrc when one exists. That file was
+# removed because fnm's --use-on-cd made every `cd` into this repo prompt to
+# install a Node the developer did not have — which silently dropped Netlify
+# onto its own default and broke the deploy preview. Pin it here instead: this
+# is read only by Netlify, so it cannot affect local shells.
+# Keep in step with node-version in .github/workflows/test.yml.
+[build.environment]
+  NODE_VERSION = "20"


### PR DESCRIPTION
## Why

Every Netlify deploy preview since #13 has failed. The cause is #13 itself — mine.

Netlify picks its build Node version from `.nvmrc` when that file exists. #13 deleted `.nvmrc` to stop `fnm --use-on-cd` prompting to install Node 20 on every `cd` into the repo, and updated GitHub Actions to pin `node-version: 20` directly. Netlify was never considered, so it silently fell back to its own default Node.

The correlation is exact:

| PR | Netlify | |
|---|---|---|
| #10, #12 | success | `.nvmrc` present |
| **#13** | **failure** | removed `.nvmrc` |
| #14 | success | branched from `main` *before* #13 merged |
| #42, #43 | failure | branched *after* |

## Fix

Pin `NODE_VERSION = "20"` in `netlify.toml`. That file is read only by Netlify, so the deploy is restored without bringing back the local shell prompt — the whole point of #13. Comment ties it to the workflow's pin so the two don't drift.

## Also worth recording

This went unnoticed for three PRs because I was filtering `gh pr checks` down to the Actions jobs while triaging, which hid four red Netlify contexts. **#42 was merged while red.** Its content (deleting a superseded script) is unaffected by Node version, so nothing shipped broken — but the check was red and I reported the PR as green.

## Verification

`npm test` 167 passed · typecheck clean · lint 0 errors · `format:check` clean (Prettier has no TOML parser but the gate is unaffected). Netlify's own preview on this PR is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)