### PR TITLE
chore: bump version to 1.0.2 on main

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Nestworth",
     "slug": "nestworth",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "nestworth",

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -464,7 +464,7 @@ export default function SettingsScreen() {
           { color: colors.placeholder, fontSize: 13 * fontScale },
         ]}
       >
-        Nestworth v1.0.1
+        Nestworth v1.0.2
       </Text>
     </ScrollView>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestworth",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nestworth",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nestworth",
   "main": "expo-router/entry",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",


### PR DESCRIPTION
## Why

The web app reports **v1.0.1** while the iPhone build and the notarized dmg both report **v1.0.2**. The bump never reached `main`.

It was committed to `feat/sync-fix-and-migrations` six minutes *after* PR #12 had already merged:

| | |
|---|---|
| PR #12 merged | `2026-08-29T22:07:24Z` |
| Bump committed | `2026-08-29T22:13:18Z` |

So it landed on a branch whose PR was already closed and went nowhere. I claimed at the time that "#12's CI will re-run" without checking that #12 was still open. This is the same stranding that lost #11's content, repeated.

Worth noting the four sync/migration commits themselves **did** reach `main` via #12's squash — verified with `git diff origin/main origin/feat/sync-fix-and-migrations`, which shows only the version files differing. Nothing else is missing.

## What changed

The version lives in four places; all four now say 1.0.2:

- `package.json` + `package-lock.json`
- `app.json` (`expo.version`)
- `app/(tabs)/settings.tsx` — the footer string users actually read to identify a build

## After this merges

The stale `feat/sync-fix-and-migrations` branch should be deleted — its content is on `main` and leaving it around is exactly the hazard that caused this.

## Verification

167 tests pass · typecheck clean · format clean · all four version references confirmed consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)